### PR TITLE
Ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+      fail-fast: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Micromamba
+      uses: mamba-org/provision-with-micromamba@v16
+      with:
+        environment-file: false
+
+    - name: Python ${{ matrix.python-version }}
+      shell: bash -l {0}
+      run: >
+        micromamba create --name TEST python=${{ matrix.python-version }} pytest --file requirements-dev.txt --channel conda-forge
+        && micromamba activate TEST
+
+    - name: Install AmplifyP
+      shell: bash -l {0}
+      run: >
+        micromamba activate TEST
+        && python -m pip install -e . --no-deps --force-reinstall
+
+
+    - name: Tests
+      shell: bash -l {0}
+      run: >
+        micromamba activate TEST
+        && python -m pytest -rxs tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "AmplifyP"
+version = "v0.0.1"
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pre-commit
+pytest


### PR DESCRIPTION
This PR adds a github actoin that runs pytest on a grid of python versions (currently 3.11 and 3.12) and operating systems (currently ubuntu, windows and macos) to ensure cross platform and multi version support.

I manually added the version to pyporject.toml so that pip install -e works. Later, we can remove this and do dynamic versioning with tags and releases