### PR TITLE
fix: correct Pages artifact path to ./dist in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: './src/dist'
+          path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This pull request merges the deploy path fix from the `dev` branch into `stable`.

### Summary of Changes
- Adjusted the upload path in `actions/upload-pages-artifact` inside `.github/workflows/deploy.yml` from `./src/dist` to `./dist` to match the actual output directory configured in `build_static.sh`.