### PR TITLE
fix: remove invalid left/right positioning from primer sequence

### DIFF
--- a/src/amplifyp/gui/views/input_view.py
+++ b/src/amplifyp/gui/views/input_view.py
@@ -599,8 +599,6 @@ class PrimerInput(ft.Container):  # type: ignore[misc]
                 value=seq_val,
                 hint_text="New Primer Sequence",
                 dense=True,
-                left=0,
-                right=0,
                 content_padding=ft.Padding(
                     5,
                     0,


### PR DESCRIPTION
The TextField was inside a Stack container but also had left=0, right=0 properties, causing a Flet error about absolute positioning only being allowed inside Stack controls. Removed these properties and updated tests to expect ft.Stack instead of ft.Column for sequence container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined input field spacing for primer rows. Right-side padding now adjusts dynamically when a row is focused and is not the last primer, improving alignment around reordering controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->