### PR TITLE
Sort amplicons by ascending Q score in PCR overview map

### DIFF
--- a/src/amplifyp/gui/views/pcr/pcr_diagram_panel.py
+++ b/src/amplifyp/gui/views/pcr/pcr_diagram_panel.py
@@ -124,11 +124,13 @@ class PCRDrawingPanel(ft.Column):  # type: ignore[misc]
         self.diagram_container.visible = True
         self.divider.visible = True
 
-        # Limit to top amplicons sorted by q_score (lower is better quality)
+        # Sort amplicons by ascending q_score (lower is better quality)
+        amplicons = sorted(amplicons, key=lambda a: a.q_score)
+        num_amplicons = len(amplicons)
+
+        # Limit to top amplicons if there are too many
         if num_amplicons > MAX_AMPLICONS_RENDER:
-            amplicons = sorted(amplicons, key=lambda a: a.q_score)[
-                :MAX_AMPLICONS_RENDER
-            ]
+            amplicons = amplicons[:MAX_AMPLICONS_RENDER]
             num_amplicons = MAX_AMPLICONS_RENDER
 
         target_length = len(pcr.template)


### PR DESCRIPTION
Always sort amplicons by ascending q_score (lower is better quality) so they appear in consistent order in the overview map, not just when exceeding MAX_AMPLICONS_RENDER.