### PR TITLE
Add version string with git SHA to title bar

### DIFF
--- a/build_static.sh
+++ b/build_static.sh
@@ -31,13 +31,15 @@ echo "==> Building static site..."
 # Clean up temporary root assets files
 rm -f "${SCRIPT_DIR}/src/assets/icon.png" "${SCRIPT_DIR}/src/assets/favicon.png" || true
 
-echo "==> Injecting browser unload warning script..."
+echo "==> Injecting browser unload warning script and git SHA..."
+GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+echo "${GIT_SHA}" > "${DIST_DIR}/.git-sha"
 "${SCRIPT_DIR}/.venv/bin/python" -c "
 import pathlib
 index_path = pathlib.Path('${DIST_DIR}/index.html')
 if index_path.exists():
     content = index_path.read_text(encoding='utf-8')
-    js_snippet = '<script>\nwindow.addEventListener(\"beforeunload\", (event) => {\n    event.preventDefault();\n    event.returnValue = \"\";\n});\n</script>\n'
+    js_snippet = '<script>\nwindow.addEventListener(\"beforeunload\", (event) => {\n    event.preventDefault();\n    event.returnValue = \"\";\n});\nwindow.__APP_SHA__ = \"${GIT_SHA}\";\n</script>\n'
     if '</head>' in content and js_snippet not in content:
         content = content.replace('</head>', js_snippet + '</head>')
         index_path.write_text(content, encoding='utf-8')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "flet>=0.85.2",
+  "pyperclip>=1.9.0",
   "pyyaml>=6.0.3",
 ]
 

--- a/src/amplifyp/gui/app.py
+++ b/src/amplifyp/gui/app.py
@@ -15,12 +15,14 @@
 
 """Main Flet application logic."""
 
+from typing import Any
+
 import flet as ft
 import yaml
 
 from amplifyp.gui.settings import GUIColors, GUISettings
 from amplifyp.gui.user_data import GUIInput
-from amplifyp.gui.util import serialize_state
+from amplifyp.gui.util import get_full_sha, get_version, serialize_state
 from amplifyp.gui.views import (
     DimerView,
     InputView,
@@ -207,6 +209,33 @@ def main(page: ft.Page) -> None:
         snack_bar.open = True
         page.update()
 
+    full_sha = get_full_sha()
+    app_version = get_version()
+
+    def on_version_click(e: Any) -> None:
+        if page.web and hasattr(page, "run_javascript"):
+            page.run_javascript(
+                f'navigator.clipboard.writeText("{full_sha}").then(function(){{}});'
+            )
+            show_snackbar("SHA copied to clipboard!")
+        else:
+            import pyperclip
+
+            pyperclip.copy(full_sha)
+            show_snackbar("SHA copied to clipboard!")
+
+    version_text = ft.GestureDetector(
+        content=ft.Text(
+            app_version,
+            size=14,
+            color=GUIColors.TEXT_ON_SURFACE,
+            opacity=0.5,
+            weight=ft.FontWeight.W_400,
+        ),
+        tooltip="Click to copy full SHA",
+        on_tap=on_version_click,
+    )
+
     async def save_state(e: ft.ControlEvent) -> None:
         input_view.sync_to_state()
         settings_view.sync_to_state()
@@ -344,6 +373,8 @@ def main(page: ft.Page) -> None:
             [
                 ft.Image(src="images/favicon.png", height=32, fit="contain"),
                 ft.Text("AmplifyP", size=20, weight=ft.FontWeight.BOLD),
+                ft.Container(width=12),
+                version_text,
             ],
             alignment=ft.MainAxisAlignment.START,
             vertical_alignment=ft.CrossAxisAlignment.CENTER,

--- a/src/amplifyp/gui/util.py
+++ b/src/amplifyp/gui/util.py
@@ -15,6 +15,8 @@
 
 """Utility functions for sequence handling and state serialization."""
 
+import os
+import subprocess
 import threading
 from collections.abc import Callable
 from typing import Any
@@ -182,3 +184,114 @@ def initialize_score_fields(
                     color=GUIColors.DIAGRAM_BLACK, size=font_size
                 ),
             )
+
+
+def get_git_sha() -> str:
+    """Get the short git commit SHA (7 chars), or 'unknown' if not available."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    try:
+        git_dir = os.path.join(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                )
+            ),
+            ".git",
+        )
+        head_path = os.path.join(git_dir, "HEAD")
+        if os.path.exists(head_path):
+            with open(head_path) as f:
+                head_content = f.read().strip()
+            if head_content.startswith("ref: refs/heads/"):
+                ref_path = head_content.replace("ref: refs/heads/", "")
+                ref_file = os.path.join(git_dir, ref_path)
+                if os.path.exists(ref_file):
+                    with open(ref_file) as f:
+                        full_sha = f.read().strip()
+                    return full_sha[:7]
+            else:
+                return head_content[:7]
+    except OSError:
+        pass
+
+    try:
+        dist_sha_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "..", ".git-sha"
+        )
+        dist_sha_path = os.path.normpath(dist_sha_path)
+        if os.path.exists(dist_sha_path):
+            with open(dist_sha_path) as f:
+                return f.read().strip()
+    except OSError:
+        pass
+
+    return "unknown"
+
+
+def get_full_sha() -> str:
+    """Get the full git commit SHA (40 chars), or 'unknown' if not available."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    try:
+        git_dir = os.path.join(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+                )
+            ),
+            ".git",
+        )
+        for ref in ("refs/heads/main", "refs/heads/master"):
+            ref_file = os.path.join(git_dir, ref)
+            if os.path.exists(ref_file):
+                with open(ref_file) as f:
+                    return f.read().strip()
+    except OSError:
+        pass
+
+    try:
+        dist_sha_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "..", "..", ".git-sha"
+        )
+        dist_sha_path = os.path.normpath(dist_sha_path)
+        if os.path.exists(dist_sha_path):
+            with open(dist_sha_path) as f:
+                return f.read().strip()
+    except OSError:
+        pass
+
+    return "unknown"
+
+
+def get_version() -> str:
+    """Return version string like 'v0.0.1 (abc1234f)' or 'v0.0.1 (unknown)'."""
+    try:
+        from importlib.metadata import version
+
+        pkg_version = version("amplifyp")
+    except Exception:
+        pkg_version = "unknown"
+
+    git_sha = get_git_sha()
+    return f"{pkg_version} ({git_sha})"


### PR DESCRIPTION
- Display package version + short SHA in title bar next to AmplifyP title
- Clicking the version string copies the full 40-char SHA to clipboard
- Desktop: uses pyperclip; Web: uses navigator.clipboard API
- build_static.sh injects SHA into dist/.git-sha and index.html for web builds
- Added pyperclip dependency to pyproject.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App version now displayed in the GUI header
  * Click the version information to copy the Git commit identifier to your clipboard with confirmation feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->