### PR TITLE
Add improved visualisation mode to GUI settings

### DIFF
--- a/src/amplifyp/gui/settings.py
+++ b/src/amplifyp/gui/settings.py
@@ -116,6 +116,11 @@ class _GUIColorsMeta(type):
         return cast(str, ft.Colors.GREY_400)
 
     @property
+    def MUTED_GREY(cls) -> str:
+        """Get muted/greyed out text color."""
+        return cast(str, ft.Colors.GREY_500)
+
+    @property
     def DUPLICATE_BG(cls) -> str:
         """Get duplicate warning background color."""
         if cls._dark_mode:
@@ -255,6 +260,7 @@ class GUISettings:
             "font_size_default": 14,
             "font_size_micro": 10,
             "font_size_table_header": 15,
+            "improved_visualisation": True,
         }
 
         # Initialize base-pair weights

--- a/src/amplifyp/gui/util.py
+++ b/src/amplifyp/gui/util.py
@@ -137,11 +137,17 @@ def create_overlapped_sequence_view(
         # mid_line = primer row (black)
         # bottom_line = bonds (blue) + template (black)
         bottom_parts = bottom_line.split("\n")
-        if len(bottom_parts) >= 2:
+        if len(bottom_parts) == 3:
             bonds_line = bottom_parts[0]
+            comp_line = bottom_parts[1]
+            template_line = bottom_parts[2]
+        elif len(bottom_parts) >= 2:
+            bonds_line = bottom_parts[0]
+            comp_line = ""
             template_line = "\n".join(bottom_parts[1:])
         else:
             bonds_line = bottom_line
+            comp_line = ""
             template_line = ""
 
         spans = [
@@ -167,6 +173,16 @@ def create_overlapped_sequence_view(
                 ),
             ),
         ]
+        if comp_line:
+            spans.append(
+                ft.TextSpan(
+                    f"{comp_line}\n",
+                    style=ft.TextStyle(
+                        color=GUIColors.MUTED_GREY,
+                        weight=ft.FontWeight.BOLD,
+                    ),
+                )
+            )
         if template_line:
             spans.append(
                 ft.TextSpan(

--- a/src/amplifyp/gui/views/pcr/primer_drawing.py
+++ b/src/amplifyp/gui/views/pcr/primer_drawing.py
@@ -273,6 +273,7 @@ def format_context_lines(
     L: int,
     N: int,
     direction: DNADirection,
+    improved_visualisation: bool = False,
 ) -> tuple[str, str, str]:
     """Format context alignment lines for binding site context map."""
     if direction == DNADirection.FWD:
@@ -325,11 +326,25 @@ def format_context_lines(
     )
 
     context_line_prefix = "Context  "
-    bottom_line = (
-        f"{bonds_line}\n"
-        f"{context_line_prefix}5'-{upstream_seq}"
-        f"{binding_seq}{downstream_seq}-3'"
-    )
+    if improved_visualisation and direction == DNADirection.FWD:
+        from amplifyp.dna import GLOBAL_COMPLEMENT_TABLE
+
+        comp_upstream = upstream_seq.translate(GLOBAL_COMPLEMENT_TABLE)
+        comp_binding = binding_seq.translate(GLOBAL_COMPLEMENT_TABLE)
+        comp_downstream = downstream_seq.translate(GLOBAL_COMPLEMENT_TABLE)
+        comp_line = (
+            f"{' ' * 9}3'-{comp_upstream}{comp_binding}{comp_downstream}-5'"
+        )
+        bottom_line = (
+            f"{bonds_line}\n"
+            f"{comp_line}\n"
+            f"{context_line_prefix}5'-{upstream_seq}{binding_seq}{downstream_seq}-3'"
+        )
+    else:
+        bottom_line = (
+            f"{bonds_line}\n"
+            f"{context_line_prefix}5'-{upstream_seq}{binding_seq}{downstream_seq}-3'"
+        )
 
     return top_line, primer_line, bottom_line
 
@@ -379,6 +394,9 @@ class ReplicationContextCard(DismissibleDetailCard):
             L=L,
             N=N,
             direction=var.direction,
+            improved_visualisation=bool(
+                settings.get("improved_visualisation", False)
+            ),
         )
 
         font_family = settings.get("font_family", "Roboto Mono")

--- a/src/amplifyp/gui/views/settings/appearance_tile.py
+++ b/src/amplifyp/gui/views/settings/appearance_tile.py
@@ -61,8 +61,16 @@ class AppearanceTile(ft.ExpansionTile):  # type: ignore[misc]
 
         self._dummy_color_deficient = ft.Checkbox(visible=False)
 
+        self.set_improved_visualisation = ft.Checkbox(
+            label="Improved Visualisation Mode",
+        )
+        self.set_improved_visualisation.on_change = self.on_change_handler
+
         self.settings_map["font_family"] = self.set_font_family
         self.settings_map["color_deficient"] = self._dummy_color_deficient
+        self.settings_map["improved_visualisation"] = (
+            self.set_improved_visualisation
+        )
 
         super().__init__(
             title=ft.Text(
@@ -80,6 +88,7 @@ class AppearanceTile(ft.ExpansionTile):  # type: ignore[misc]
                                     [
                                         self.set_font_family,
                                         self.set_color_scheme,
+                                        self.set_improved_visualisation,
                                         self._dummy_color_deficient,
                                     ],
                                     spacing=15,

--- a/src/amplifyp/gui/views/settings_view.py
+++ b/src/amplifyp/gui/views/settings_view.py
@@ -171,6 +171,11 @@ class SettingsView(ft.ListView):  # type: ignore[misc]
         """Get the color deficient mode checkbox."""
         return self.appearance_tile.set_color_deficient
 
+    @property
+    def set_improved_visualisation(self) -> ft.Checkbox:
+        """Get the improved visualisation mode checkbox."""
+        return self.appearance_tile.set_improved_visualisation
+
     def _build_action_buttons(self) -> ft.Row:
         """Build the Action buttons Row (Apply & Reset)."""
         return ft.Row(
@@ -246,6 +251,7 @@ class SettingsView(ft.ListView):  # type: ignore[misc]
             "font_family": "Roboto Mono",
             "color_deficient": False,
             "dark_mode": "system",
+            "improved_visualisation": True,
         }
 
         for r_char in Nucleotides.PRIMER:

--- a/tests/gui_state_test.py
+++ b/tests/gui_state_test.py
@@ -47,6 +47,7 @@ def test_gui_state_save_load() -> None:
     settings_view = SettingsView(mock_page)
     settings_view.set_primability_cutoff.value = "0.9"
     settings_view.set_amp4_compat.value = True
+    settings_view.set_improved_visualisation.value = True
     settings_view.set_tm_dna_conc.value = "100.0"
     settings_view.set_tm_method.value = "Lander / Amplify 4"
     settings_view.set_font_family.value = "Courier New"
@@ -120,6 +121,7 @@ def test_gui_state_save_load() -> None:
     # Verify SettingsView
     assert new_settings_view.set_primability_cutoff.value == "0.9"
     assert new_settings_view.set_amp4_compat.value
+    assert new_settings_view.set_improved_visualisation.value
     assert new_settings_view.set_tm_dna_conc.value == "100.0"
     assert new_settings_view.set_tm_method.value == "Lander / Amplify 4"
     assert new_settings_view.set_font_family.value == "Courier New"
@@ -129,6 +131,7 @@ def test_gui_state_save_load() -> None:
     )
     assert new_settings_view.settings["dark_mode"] is True
     assert new_settings_view.settings["color_deficient"] is True
+    assert new_settings_view.settings["improved_visualisation"] is True
     assert new_settings_view.settings_map["bp_score_G_G"].value == "99.0"
     assert new_settings_view.settings_map["pd_score_G_G"].value == "99.0"
     # Check a default value wasn't changed
@@ -165,7 +168,7 @@ def test_settings_view_buttons() -> None:
     # Change some values
     settings_view.set_primability_cutoff.value = "0.95"
     settings_view.set_amp4_compat.value = True
-    settings_view.set_tm_method.value = "Lander / Amplify 4"
+    settings_view.set_improved_visualisation.value = True
     settings_view.settings_map["bp_score_G_G"].value = "50.0"
     settings_view.settings_map["pd_score_G_G"].value = "50.0"
 
@@ -183,7 +186,7 @@ def test_settings_view_buttons() -> None:
     assert apply_called
     assert settings_view.settings["primability_cutoff"] == "0.95"
     assert settings_view.settings["amp4_compat"] is True
-    assert settings_view.settings["tm_method"] == "Lander / Amplify 4"
+    assert settings_view.settings["improved_visualisation"] is True
     assert settings_view.settings["bp_score_G_G"] == "50.0"
     assert settings_view.settings["pd_score_G_G"] == "50.0"
 
@@ -196,9 +199,11 @@ def test_settings_view_buttons() -> None:
     )
     assert settings_view.settings["bp_score_G_G"] == "100"
     assert settings_view.settings["pd_score_G_G"] == "-20"
+    assert settings_view.settings["improved_visualisation"] is True
     # Controls should be updated too
     assert settings_view.set_primability_cutoff.value == "0.8"
     assert settings_view.set_amp4_compat.value is False
+    assert settings_view.set_improved_visualisation.value is True
     assert (
         settings_view.set_tm_method.value
         == "SantaLucia 1998 / Owczarzy 2008 (Default)"

--- a/tests/pcr_view_test.py
+++ b/tests/pcr_view_test.py
@@ -347,3 +347,59 @@ def test_pcr_view_primers_same_3prime_end_different_5prime() -> None:
     ]
     assert "P1" in texts
     assert "P2" in texts
+
+
+def test_pcr_view_click_context_map_improved_visualisation() -> None:
+    """Test clicking a primer binding site shows RC strand in context map."""
+    mock_page = MagicMock(spec=ft.Page)
+    mock_page.dialog = None
+    mock_page.width = 800
+
+    input_data = GUIInput()
+    input_data.template = (
+        "tTccACTGCGAATCATTAAAGTGGGTATCACAAATTTGGGAGTTTTCACCAAGGCTGCAC"
+    )
+    input_data.template_circular = False
+    input_data.primers = [
+        {"name": "10290", "seq": "tTccACTGCGAATCATTAAA", "active": True},
+        {"name": "rev_primer", "seq": "gTgcAGCCTTGGTGAAAACT", "active": True},
+    ]
+
+    view = PCRView(mock_page, input_data)
+    # Turn on improved visualisation
+    view.settings["improved_visualisation"] = True
+    view.run_pcr()
+
+    gesture_detectors = [
+        ctrl
+        for ctrl in view.diagram_stack.controls
+        if isinstance(ctrl, ft.GestureDetector)
+    ]
+    assert len(gesture_detectors) >= 2
+
+    # Click on the first gesture detector (forward binding site)
+    fwd_detector = gesture_detectors[0]
+    fwd_detector.on_tap(MagicMock())
+
+    assert len(view.result_list.controls) == 1
+    card = view.result_list.controls[0]
+    assert isinstance(card, ft.Card)
+
+    # Extract diagram_text
+    diagram_text = card.content.content.controls[2].content.controls[0]
+    assert isinstance(diagram_text, ft.Text)
+
+    # Check spans
+    # It should have a span for the comp_line with MUTED_GREY color
+    from amplifyp.gui.settings import GUIColors
+
+    comp_spans = [
+        span
+        for span in diagram_text.spans
+        if getattr(span, "style", None)
+        and span.style.color == GUIColors.MUTED_GREY
+    ]
+    assert len(comp_spans) == 1
+    # Check that it contains "3'-" and "-5'" and the translated comp sequence
+    assert "3'-" in comp_spans[0].text
+    assert "-5'" in comp_spans[0].text


### PR DESCRIPTION
Add an 'improved visualisation mode' setting (on by default) under Appearance Settings in the GUI. When enabled, the context map displays the reverse complementary strand of the template context above the template itself for forward primers, colored in a new MUTED_GREY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Improved Visualisation Mode" toggle in appearance settings
  * PCR primer context now displays complementary strand visualization in muted grey when the improved mode is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->