### PR TITLE
Replace codespell with typos-cli configured for British English

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,10 @@ repos:
       - id: ruff-format
       - id: ruff-check
         args: [--fix]
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.36.0
     hooks:
-      - id: codespell
-        args:
-          - --skip
-          - tests/examples/save_states/*
+      - id: typos
   - repo: https://github.com/jendrikseipp/vulture
     rev: v2.16
     hooks:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ ______________________________________________________________________
   Flutter-based UI framework) providing a beautiful, fully responsive app for
   desktop and web browsers.
 - **Scoring Engine**: Calculates primability and stability scores using highly
-  customizable length-wise and pairwise weight tables.
-- **State Serialization**: Save and load templates, primers, cutoffs, and
+  customisable length-wise and pairwise weight tables.
+- **State Serialisation**: Save and load templates, primers, cutoffs, and
   replication configurations seamlessly using YAML files.
 - **Programmatic Python API**: A developer-friendly, fully typed API to run
   simulations, dimer analyses, or thermodynamic melting calculations within your
@@ -91,8 +91,8 @@ The GUI offers intuitive workflows to:
 
 1. **Input template DNA sequences** and configure linear/circular topologies.
 1. **Manage multiple primers** with individual sequences and custom names.
-1. **Customize thresholds** for primability and stability cutoffs.
-1. **Simulate PCR** to visualize products, lanes, and details of binding sites.
+1. **Customise thresholds** for primability and stability cutoffs.
+1. **Simulate PCR** to visualise products, lanes, and details of binding sites.
 1. **Save/Load projects** to resume work easily.
 
 ______________________________________________________________________
@@ -115,7 +115,7 @@ template = DNA(template_seq, DNAType.LINEAR, name="MyTemplate")
 primer_fwd = Primer("AGCT...", name="FwdPrimer")
 primer_rev = Primer("TCGA...", name="RevPrimer")
 
-# 2. Initialize the Amplicon Generator
+# 2. Initialise the Amplicon Generator
 generator = AmpliconGenerator(template)
 
 # 3. Create Replication Configurations for each primer

--- a/src/amplifyp/amplicon.py
+++ b/src/amplifyp/amplicon.py
@@ -77,7 +77,7 @@ class Amplicon:
     def q_score_report_str(self, verbose: bool = False) -> str:
         """Generate textual report based on the amplicon q-score.
 
-        Uses a set of predefined thresholds to categorize the quality score
+        Uses a set of predefined thresholds to categorise the quality score
         into descriptive strings ranging from "good" to "very weak".
 
         Args:
@@ -129,7 +129,7 @@ class AmpliconGenerator:
     """
 
     def __init__(self, template: DNA) -> None:
-        """Initialize an AmpliconGenerator.
+        """Initialise an AmpliconGenerator.
 
         Args:
             template (DNA): The template DNA sequence.

--- a/src/amplifyp/dimer.py
+++ b/src/amplifyp/dimer.py
@@ -87,7 +87,7 @@ class PrimerDimerGenerator:
     def __init__(
         self, settings: PrimerDimerSettings = GLOBAL_PRIMER_DIMER_SETTINGS
     ):
-        """Initialize the PrimerDimerGenerator.
+        """Initialise the PrimerDimerGenerator.
 
         Args:
             settings (PrimerDimerSettings): Settings to use for dimer

--- a/src/amplifyp/dna.py
+++ b/src/amplifyp/dna.py
@@ -105,7 +105,7 @@ class DNA:
 
     This class encapsulates a DNA sequence and its properties, such as its type
     (linear, circular, or primer), name, and direction. It provides methods for
-    manipulating and analyzing the DNA sequence, such as complementing,
+    manipulating and analysing the DNA sequence, such as complementing,
     reversing, and padding.
 
     Attributes:
@@ -124,7 +124,7 @@ class DNA:
         name: str | None = None,
         direction: bool | DNADirection = DNADirection.FWD,
     ) -> None:
-        """Initializes a new DNA object.
+        """Initialises a new DNA object.
 
         Args:
             seq (str): The raw DNA sequence. Whitespace will be removed.
@@ -147,7 +147,7 @@ class DNA:
             raise InvalidDNATypeError()
 
         self.__seq: str = "".join(seq.split())
-        # Optimization: cache the uppercase sequence to avoid repeated
+        # Optimisation: cache the uppercase sequence to avoid repeated
         # allocations in _count_bases and other methods.
         seq_upper = self.__seq.upper()
         if seq_upper == self.__seq:
@@ -395,7 +395,7 @@ class Primer(DNA):
         sequence: str,
         name: str | None = None,
     ) -> None:
-        """Initializes a Primer object.
+        """Initialises a Primer object.
 
         Args:
             sequence (str): The nucleotide sequence of the primer.

--- a/src/amplifyp/errors.py
+++ b/src/amplifyp/errors.py
@@ -28,7 +28,7 @@ class DuplicateRepliconfError(ValueError):
         self,
         message: str = "The Repliconf is already in the AmpliconGenerator.",
     ) -> None:
-        """Initialize the duplicate repliconf error."""
+        """Initialise the duplicate repliconf error."""
         super().__init__(message)
 
 
@@ -36,7 +36,7 @@ class PrimerNotFoundError(ValueError):
     """Exception raised when a primer is not found."""
 
     def __init__(self, primer: object) -> None:
-        """Initialize the primer not found error."""
+        """Initialise the primer not found error."""
         super().__init__(f"Primer {primer} not found")
 
 
@@ -44,7 +44,7 @@ class DuplicatedNameError(ValueError):
     """Exception raised when a primer name is already added."""
 
     def __init__(self, name: str) -> None:
-        """Initialize the duplicated name error."""
+        """Initialise the duplicated name error."""
         super().__init__(f"Primer name '{name}' already added")
 
 
@@ -52,7 +52,7 @@ class DuplicatedSequenceError(ValueError):
     """Exception raised when a primer sequence is already added."""
 
     def __init__(self, sequence: str) -> None:
-        """Initialize the duplicated sequence error."""
+        """Initialise the duplicated sequence error."""
         super().__init__(f"Primer sequence '{sequence}' already added")
 
 
@@ -60,7 +60,7 @@ class InvalidDNATypeError(TypeError):
     """Exception raised when a DNA type is not valid."""
 
     def __init__(self, message: str = "Invalid DNA type.") -> None:
-        """Initialize the invalid DNA type error."""
+        """Initialise the invalid DNA type error."""
         super().__init__(message)
 
 
@@ -68,7 +68,7 @@ class InvalidDNASequenceError(ValueError):
     """Exception raised when a DNA sequence contains invalid characters."""
 
     def __init__(self, invalid_chars: set[str] | list[str]) -> None:
-        """Initialize the invalid DNA sequence error."""
+        """Initialise the invalid DNA sequence error."""
         sorted_chars = ", ".join(sorted(invalid_chars))
         super().__init__(
             f"The DNA sequence contains invalid characters: {sorted_chars}"
@@ -85,7 +85,7 @@ class ReplicationOriginLengthError(ValueError):
         self,
         message: str = "The target has to have the same length as the primer.",
     ) -> None:
-        """Initialize the replication origin length error."""
+        """Initialise the replication origin length error."""
         super().__init__(message)
 
 
@@ -96,7 +96,7 @@ class BasePairTableDimensionError(ValueError):
 class RowLengthMismatchError(BasePairTableDimensionError):
     """Exception raised when a weight table's row length does not match.
 
-    The row length must match the expected size at initialization.
+    The row length must match the expected size at initialisation.
     """
 
     def __init__(
@@ -105,14 +105,14 @@ class RowLengthMismatchError(BasePairTableDimensionError):
             "BasePairWeightsTbl: row length mismatch at initialisation."
         ),
     ) -> None:
-        """Initialize the row length mismatch error."""
+        """Initialise the row length mismatch error."""
         super().__init__(message)
 
 
 class ColumnLengthMismatchError(BasePairTableDimensionError):
     """Exception raised when a weight table's column length does not match.
 
-    The column length must match the expected size at initialization.
+    The column length must match the expected size at initialisation.
     """
 
     def __init__(
@@ -121,7 +121,7 @@ class ColumnLengthMismatchError(BasePairTableDimensionError):
             "BasePairWeightsTbl: column length mismatch at initialisation."
         ),
     ) -> None:
-        """Initialize the column length mismatch error."""
+        """Initialise the column length mismatch error."""
         super().__init__(message)
 
 
@@ -135,7 +135,7 @@ class InvalidStartDirectionError(AmpliconDirectionError):
     def __init__(
         self, message: str = "Start direction must be forward."
     ) -> None:
-        """Initialize the invalid start direction error."""
+        """Initialise the invalid start direction error."""
         super().__init__(message)
 
 
@@ -143,7 +143,7 @@ class InvalidEndDirectionError(AmpliconDirectionError):
     """Exception raised when an amplicon end direction is not REV."""
 
     def __init__(self, message: str = "End direction must be reverse.") -> None:
-        """Initialize the invalid end direction error."""
+        """Initialise the invalid end direction error."""
         super().__init__(message)
 
 
@@ -159,7 +159,7 @@ class InvalidIndexOrderError(ValueError):
             "End index must be greater than start index for linear DNA."
         ),
     ) -> None:
-        """Initialize the invalid index order error."""
+        """Initialise the invalid index order error."""
         super().__init__(message)
 
 
@@ -177,7 +177,7 @@ class TemplateMismatchError(ValueError):
             "AmpliconGenerator."
         ),
     ) -> None:
-        """Initialize the template mismatch error."""
+        """Initialise the template mismatch error."""
         super().__init__(message)
 
 
@@ -195,5 +195,5 @@ class InvalidAmpliconRangeError(NotImplementedError):
             "bigger than the end index on a linear DNA template."
         ),
     ) -> None:
-        """Initialize the invalid amplicon range error."""
+        """Initialise the invalid amplicon range error."""
         super().__init__(message)

--- a/src/amplifyp/gui/app.py
+++ b/src/amplifyp/gui/app.py
@@ -23,4 +23,4 @@ from amplifyp.gui.controller import GUIController
 def main(page: ft.Page) -> None:
     """Main entry point for the Flet application."""
     controller = GUIController(page)
-    controller.initialize()
+    controller.initialise()

--- a/src/amplifyp/gui/controller.py
+++ b/src/amplifyp/gui/controller.py
@@ -24,7 +24,7 @@ import yaml
 from amplifyp.gui.colours import GUIColours
 from amplifyp.gui.settings import GUISettings
 from amplifyp.gui.user_data import GUIInput
-from amplifyp.gui.util import NotificationHelper, get_version, serialize_state
+from amplifyp.gui.util import NotificationHelper, get_version, serialise_state
 from amplifyp.gui.views import (
     DimerView,
     InputView,
@@ -37,7 +37,7 @@ class GUIController:
     """Manages GUI state, event handlers, views and main orchestration."""
 
     def __init__(self, page: ft.Page) -> None:
-        """Initialize the GUIController."""
+        """Initialise the GUIController."""
         self.page = page
         self.input_data = GUIInput()
         self.settings = GUISettings()
@@ -69,7 +69,7 @@ class GUIController:
             NotificationHelper, None
         )
 
-    def initialize(self) -> None:
+    def initialise(self) -> None:
         """Configure page setup, window events, views, and custom layout."""
         self.page.overlay.clear()
         self.page.title = "AmplifyP"
@@ -440,7 +440,7 @@ class GUIController:
                 "input": self.input_data.to_dict(),
                 "settings": self.settings.to_dict(),
             }
-            yaml_str = serialize_state(combined)
+            yaml_str = serialise_state(combined)
 
             from amplifyp.gui.util import save_and_write_file
 

--- a/src/amplifyp/gui/settings.py
+++ b/src/amplifyp/gui/settings.py
@@ -54,7 +54,7 @@ class GUISettings:
     """Encapsulates configuration settings for the GUI."""
 
     def __init__(self, settings_dict: dict[str, Any] | None = None) -> None:
-        """Initialize GUISettings with optional dictionary or defaults."""
+        """Initialise GUISettings with optional dictionary or defaults."""
         from amplifyp.dna import Nucleotides
 
         self._settings: dict[str, Any] = {
@@ -85,7 +85,7 @@ class GUISettings:
             "improved_visualisation": True,
         }
 
-        # Initialize base-pair weights
+        # Initialise base-pair weights
         for r_char in Nucleotides.PRIMER:
             for c_char in Nucleotides.TEMPLATE:
                 if c_char == Nucleotides.GAP:
@@ -95,7 +95,7 @@ class GUISettings:
                     DEFAULT_BASE_PAIR_WEIGHTS[r_char, c_char]
                 )
 
-        # Initialize primer-dimer weights
+        # Initialise primer-dimer weights
         for r_char in Nucleotides.PRIMER:
             for c_char in Nucleotides.PRIMER:
                 key = f"pd_score_{r_char}_{c_char}"
@@ -294,7 +294,7 @@ class GUISettings:
         return calculate_tm_santalucia_1998_owczarzy_2008(primer, tm_settings)
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert settings to a dictionary for serialization."""
+        """Convert settings to a dictionary for serialisation."""
         return dict(self._settings)
 
     def from_dict(self, settings_dict: dict[str, Any]) -> None:

--- a/src/amplifyp/gui/user_data.py
+++ b/src/amplifyp/gui/user_data.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Centralized GUI state and user data orchestrator."""
+"""Centralised GUI state and user data orchestrator."""
 
 from typing import Any
 
@@ -29,7 +29,7 @@ class GUIInput:
         template_circular: bool = False,
         primers: list[dict[str, Any]] | None = None,
     ) -> None:
-        """Initialize GUIInput."""
+        """Initialise GUIInput."""
         self.template: str = template
         self.template_circular: bool = template_circular
         self.primers: list[dict[str, Any]] = (
@@ -61,7 +61,7 @@ class GUIInput:
             )
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert input data to a dictionary for serialization."""
+        """Convert input data to a dictionary for serialisation."""
         return {
             "template": format_sequence(self.template),
             "template_circular": self.template_circular,

--- a/src/amplifyp/gui/util.py
+++ b/src/amplifyp/gui/util.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Utility functions for sequence handling and state serialization."""
+"""Utility functions for sequence handling and state serialisation."""
 
 import os
 import subprocess
@@ -74,8 +74,8 @@ def format_sequence(seq: str, wrap_length: int = 80) -> str:
     )
 
 
-def serialize_state(state: dict[str, object]) -> str:
-    """Serialize state dict to YAML string, handling multiline strings."""
+def serialise_state(state: dict[str, object]) -> str:
+    """Serialise state dict to YAML string, handling multiline strings."""
 
     def multiline_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
         if "\n" in data:
@@ -233,7 +233,7 @@ class Debouncer:
     """A thread-based debounce helper for delaying UI actions."""
 
     def __init__(self, delay_seconds: float = 0.15) -> None:
-        """Initialize the Debouncer."""
+        """Initialise the Debouncer."""
         self.delay_seconds = delay_seconds
         self._timer: threading.Timer | None = None
 
@@ -259,7 +259,7 @@ class Debouncer:
             self._timer = None
 
 
-def initialize_score_fields(
+def initialise_score_fields(
     settings_map: dict[str, Any],
     prefix: str,
     row_headers: list[str],
@@ -267,7 +267,7 @@ def initialize_score_fields(
     on_change_handler: Any,
     font_size: int,
 ) -> None:
-    """Initialize a grid of text fields for a score table in settings_map."""
+    """Initialise a grid of text fields for a score table in settings_map."""
     from amplifyp.gui.colours import GUIColours
 
     for r_char in row_headers:
@@ -507,12 +507,12 @@ async def save_and_write_file(
 class NotificationHelper:
     """Helper class to manage user notifications and messages.
 
-    Wraps flet SnackBar usage to allow easy swapping to dialogs or other
+    Wraps flet SnackBar usage to allow easy swapping to dialogues or other
     components.
     """
 
     def __init__(self, page: ft.Page) -> None:
-        """Initialize the NotificationHelper."""
+        """Initialise the NotificationHelper."""
         self.page = page
         self._snack_bar = ft.SnackBar(ft.Text(""), open=False)
         self.page.overlay.append(self._snack_bar)

--- a/src/amplifyp/gui/views/dimer/dimer_card.py
+++ b/src/amplifyp/gui/views/dimer/dimer_card.py
@@ -34,7 +34,7 @@ class DimerCard(ft.Card):  # type: ignore[misc]
         settings: GUISettings,
         font_family: str = "Roboto Mono",
     ) -> None:
-        """Initialize the DimerCard."""
+        """Initialise the DimerCard."""
         super().__init__()
         self.d = d
         self.settings = settings

--- a/src/amplifyp/gui/views/dimer/dimer_view.py
+++ b/src/amplifyp/gui/views/dimer/dimer_view.py
@@ -38,7 +38,7 @@ class DimerView(ft.Column):  # type: ignore[misc]
         input_data: GUIInput | None = None,
         settings: GUISettings | None = None,
     ) -> None:
-        """Initialize the DimerView."""
+        """Initialise the DimerView."""
         super().__init__(expand=True)
         self.app_page = page
         self.input_data = input_data if input_data is not None else GUIInput()

--- a/src/amplifyp/gui/views/input/input_view.py
+++ b/src/amplifyp/gui/views/input/input_view.py
@@ -40,7 +40,7 @@ class InputView(ft.Row):  # type: ignore[misc]
         on_change: Any | None = None,
         on_stop_editing: Any | None = None,
     ) -> None:
-        """Initialize the InputView."""
+        """Initialise the InputView."""
         super().__init__(
             expand=True, vertical_alignment=ft.CrossAxisAlignment.STRETCH
         )
@@ -388,7 +388,7 @@ class InputView(ft.Row):  # type: ignore[misc]
         return self.input_data.get_active_primers()
 
     def get_all_primers_state(self) -> list[dict[str, Any]]:
-        """Get all primers (active and inactive) for serialization."""
+        """Get all primers (active and inactive) for serialisation."""
         primers: list[dict[str, Any]] = []
         for p in self.input_data.primers:
             if (
@@ -406,7 +406,7 @@ class InputView(ft.Row):  # type: ignore[misc]
         return primers
 
     def get_state(self) -> dict[str, Any]:
-        """Get the current input data state for serialization."""
+        """Get the current input data state for serialisation."""
         self.sync_to_state()
         return self.input_data.to_dict()
 

--- a/src/amplifyp/gui/views/input/primer_action_controller.py
+++ b/src/amplifyp/gui/views/input/primer_action_controller.py
@@ -31,7 +31,7 @@ class PrimerActionController:
     """
 
     def __init__(self, owner: "PrimerInput") -> None:
-        """Initialize the PrimerActionController."""
+        """Initialise the PrimerActionController."""
         self.owner = owner
 
     def handle_row_click(self, idx: int, name_edit: ft.TextField) -> None:

--- a/src/amplifyp/gui/views/input/primer_file_manager.py
+++ b/src/amplifyp/gui/views/input/primer_file_manager.py
@@ -35,7 +35,7 @@ class PrimerFileManager:
         on_change_handler: Any,
         show_notification: Any,
     ) -> None:
-        """Initialize the PrimerFileManager."""
+        """Initialise the PrimerFileManager."""
         self.app_page = page
         self.input_data = input_data
         self.on_update_ui = on_update_ui
@@ -80,8 +80,8 @@ class PrimerFileManager:
             )
         return parsed_primers
 
-    def _serialize_primers_to_tsv(self, primers: list[dict[str, Any]]) -> str:
-        """Serialize primers list to a TSV string."""
+    def _serialise_primers_to_tsv(self, primers: list[dict[str, Any]]) -> str:
+        """Serialise primers list to a TSV string."""
         output = io.StringIO()
         writer = csv.writer(output, delimiter="\t")
         for p in primers:
@@ -143,7 +143,7 @@ class PrimerFileManager:
             self.show_notification("No primers to save.")
             return
 
-        tsv_content = self._serialize_primers_to_tsv(primers_to_save)
+        tsv_content = self._serialise_primers_to_tsv(primers_to_save)
 
         from amplifyp.gui.util import save_and_write_file
 

--- a/src/amplifyp/gui/views/input/primer_header.py
+++ b/src/amplifyp/gui/views/input/primer_header.py
@@ -34,7 +34,7 @@ class PrimerHeader(ft.Container):  # type: ignore[misc]
         on_divider_pan_end: Any,
         name_column_width: float,
     ) -> None:
-        """Initialize the PrimerHeader."""
+        """Initialise the PrimerHeader."""
         self.settings = settings
         self.all_primers_checkbox = ft.Checkbox(
             value=None,

--- a/src/amplifyp/gui/views/input/primer_info_panel.py
+++ b/src/amplifyp/gui/views/input/primer_info_panel.py
@@ -29,7 +29,7 @@ class PrimerInfoPanel(ft.Card):  # type: ignore[misc]
     """Panel to display Tm, redundancy, and dimer info for a primer."""
 
     def __init__(self, settings: GUISettings, font_family: str) -> None:
-        """Initialize the PrimerInfoPanel."""
+        """Initialise the PrimerInfoPanel."""
         super().__init__()
         self.settings = settings
         self._on_dismiss_callback: Any = None

--- a/src/amplifyp/gui/views/input/primer_input.py
+++ b/src/amplifyp/gui/views/input/primer_input.py
@@ -50,7 +50,7 @@ class PrimerInput(ft.Container):  # type: ignore[misc]
         clear_primers_callback: Any,
         delete_selected_callback: Any,
     ) -> None:
-        """Initialize the PrimerInput component."""
+        """Initialise the PrimerInput component."""
         super().__init__(expand=5)
         self.app_page = page
         self.settings = settings

--- a/src/amplifyp/gui/views/input/primer_layout_manager.py
+++ b/src/amplifyp/gui/views/input/primer_layout_manager.py
@@ -30,7 +30,7 @@ class PrimerLayoutManager:
     """
 
     def __init__(self, owner: "PrimerInput") -> None:
-        """Initialize the PrimerLayoutManager."""
+        """Initialise the PrimerLayoutManager."""
         self.owner = owner
 
     def get_panel_width(self) -> float:

--- a/src/amplifyp/gui/views/input/primer_list.py
+++ b/src/amplifyp/gui/views/input/primer_list.py
@@ -30,7 +30,7 @@ class PrimerList(ft.ListView):  # type: ignore[misc]
         self,
         primer_input: Any,
     ) -> None:
-        """Initialize the PrimerList."""
+        """Initialise the PrimerList."""
         super().__init__(
             expand=True,
             spacing=0,
@@ -54,7 +54,7 @@ class PrimerList(ft.ListView):  # type: ignore[misc]
         )
         self.controls.clear()
 
-        # Initialize with a single empty row if the list is completely empty
+        # Initialise with a single empty row if the list is completely empty
         if not self.primer_input.input_data.primers:
             self.primer_input.input_data.primers = [
                 {"name": "", "seq": "", "active": False}

--- a/src/amplifyp/gui/views/input/primer_row.py
+++ b/src/amplifyp/gui/views/input/primer_row.py
@@ -49,7 +49,7 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
         is_focused: bool,
         is_last_row: bool,
     ) -> None:
-        """Initialize the PrimerRow."""
+        """Initialise the PrimerRow."""
         has_err = bool(name_error or seq_error)
         super().__init__(
             data=idx,

--- a/src/amplifyp/gui/views/input/primer_toolbar.py
+++ b/src/amplifyp/gui/views/input/primer_toolbar.py
@@ -30,7 +30,7 @@ class PrimerToolbar(ft.Row):  # type: ignore[misc]
         on_clear: Any,
         on_delete_selected: Any,
     ) -> None:
-        """Initialize the PrimerToolbar."""
+        """Initialise the PrimerToolbar."""
         self.save_button = ft.FilledTonalButton(
             "Save",
             icon=ft.Icons.FILE_DOWNLOAD,

--- a/src/amplifyp/gui/views/input/template_input.py
+++ b/src/amplifyp/gui/views/input/template_input.py
@@ -39,7 +39,7 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
         handle_field_submit: Any,
         clear_template_callback: Any,
     ) -> None:
-        """Initialize the TemplateInput component."""
+        """Initialise the TemplateInput component."""
         super().__init__(expand=5)
         self.app_page = page
         self.settings = settings

--- a/src/amplifyp/gui/views/pcr/amplicon_drawing.py
+++ b/src/amplifyp/gui/views/pcr/amplicon_drawing.py
@@ -42,7 +42,7 @@ class DrawnAmplicon:
         on_click: Callable[[], None],
         v_frag_start: float | None = None,
     ) -> None:
-        """Initialize the DrawnAmplicon."""
+        """Initialise the DrawnAmplicon."""
         self.amp = amp
         self.idx = idx
         self.target_length = target_length
@@ -178,7 +178,7 @@ class AmpliconDetailCard(DismissibleDetailCard):
         settings: Any,
         dismiss_callback: Callable[[ft.Card], None],
     ) -> None:
-        """Initialize the AmpliconDetailCard."""
+        """Initialise the AmpliconDetailCard."""
         card_id = (
             f"amplicon_{amp.fwd_origin.name}_{amp.rev_origin.name}_"
             f"{amp.start.index}_{amp.end.index}"

--- a/src/amplifyp/gui/views/pcr/dismissible_detail_card.py
+++ b/src/amplifyp/gui/views/pcr/dismissible_detail_card.py
@@ -32,7 +32,7 @@ class DismissibleDetailCard(ft.Card):  # type: ignore[misc]
         dismiss_callback: Callable[[ft.Card], None],
         body_controls: list[ft.Control],
     ) -> None:
-        """Initialize the DismissibleDetailCard."""
+        """Initialise the DismissibleDetailCard."""
         super().__init__()
         self._card_id = card_id
 

--- a/src/amplifyp/gui/views/pcr/pcr_diagram_panel.py
+++ b/src/amplifyp/gui/views/pcr/pcr_diagram_panel.py
@@ -45,7 +45,7 @@ class PCRDrawingPanel(ft.Column):  # type: ignore[misc]
         on_primer_click: Callable[[str, int, Any, Any], None],
         on_amplicon_click: Callable[[Any], None],
     ) -> None:
-        """Initialize the PCRDrawingPanel."""
+        """Initialise the PCRDrawingPanel."""
         super().__init__(spacing=0, tight=True)
         self.app_page = page
         self.settings = settings

--- a/src/amplifyp/gui/views/pcr/pcr_view.py
+++ b/src/amplifyp/gui/views/pcr/pcr_view.py
@@ -40,7 +40,7 @@ class PCRView(ft.Column):  # type: ignore[misc]
         input_data: GUIInput | None = None,
         settings: GUISettings | None = None,
     ) -> None:
-        """Initialize the PCRView."""
+        """Initialise the PCRView."""
         super().__init__(expand=True)
         self.app_page = page
 

--- a/src/amplifyp/gui/views/pcr/primer_drawing.py
+++ b/src/amplifyp/gui/views/pcr/primer_drawing.py
@@ -45,7 +45,7 @@ class DrawnPrimer:
         on_click: Callable[[], None],
         x_shifted: float | None = None,
     ) -> None:
-        """Initialize the DrawnPrimer."""
+        """Initialise the DrawnPrimer."""
         self.name = name
         self.index = index
         self.conf = conf
@@ -361,7 +361,7 @@ class ReplicationContextCard(DismissibleDetailCard):
         settings: Any,
         dismiss_callback: Callable[[ft.Card], None],
     ) -> None:
-        """Initialize the ReplicationContextCard."""
+        """Initialise the ReplicationContextCard."""
         card_id = f"context_{primer_name}_{padded_idx}"
 
         origin = conf.origin(var)

--- a/src/amplifyp/gui/views/settings/appearance_tile.py
+++ b/src/amplifyp/gui/views/settings/appearance_tile.py
@@ -30,7 +30,7 @@ class AppearanceTile(ft.ExpansionTile):  # type: ignore[misc]
         on_change_handler: Any,
         header_size: int,
     ) -> None:
-        """Initialize the AppearanceTile."""
+        """Initialise the AppearanceTile."""
         self.settings = settings
         self.settings_map = settings_map
         self.on_change_handler = on_change_handler

--- a/src/amplifyp/gui/views/settings/base_score_tile.py
+++ b/src/amplifyp/gui/views/settings/base_score_tile.py
@@ -38,7 +38,7 @@ class ScoreTable(ft.Column):  # type: ignore[misc]
         font_size_micro: int,
         font_size_table_header: int,
     ) -> None:
-        """Initialize the ScoreTable."""
+        """Initialise the ScoreTable."""
         self.label = label
         self.row_headers = row_headers
         self.col_headers = col_headers
@@ -209,15 +209,15 @@ class BaseScoreTile(ft.ExpansionTile):  # type: ignore[misc]
         col_label: str,
         parameter_controls: list[ft.Control],
     ) -> None:
-        """Initialize the BaseScoreTile."""
+        """Initialise the BaseScoreTile."""
         self.settings = settings
         self.settings_map = settings_map
         self.on_change_handler = on_change_handler
 
-        # Map initialization (must happen before building ScoreTable)
-        from amplifyp.gui.util import initialize_score_fields
+        # Map initialisation (must happen before building ScoreTable)
+        from amplifyp.gui.util import initialise_score_fields
 
-        initialize_score_fields(
+        initialise_score_fields(
             settings_map=self.settings_map,
             prefix=score_table_prefix,
             row_headers=row_headers,

--- a/src/amplifyp/gui/views/settings/dimer_tile.py
+++ b/src/amplifyp/gui/views/settings/dimer_tile.py
@@ -35,7 +35,7 @@ class DimerTile(BaseScoreTile):
         font_size_micro: int,
         font_size_table_header: int,
     ) -> None:
-        """Initialize the DimerTile."""
+        """Initialise the DimerTile."""
         from amplifyp.dna import Nucleotides
 
         self.set_pd_min_overlap = ft.TextField(

--- a/src/amplifyp/gui/views/settings/replication_tile.py
+++ b/src/amplifyp/gui/views/settings/replication_tile.py
@@ -35,7 +35,7 @@ class ReplicationTile(BaseScoreTile):
         font_size_micro: int,
         font_size_table_header: int,
     ) -> None:
-        """Initialize the ReplicationTile."""
+        """Initialise the ReplicationTile."""
         from amplifyp.dna import Nucleotides
 
         self.set_primability_cutoff = ft.TextField(

--- a/src/amplifyp/gui/views/settings/tm_tile.py
+++ b/src/amplifyp/gui/views/settings/tm_tile.py
@@ -30,7 +30,7 @@ class TmTile(ft.ExpansionTile):  # type: ignore[misc]
         on_change_handler: Any,
         header_size: int,
     ) -> None:
-        """Initialize the TmTile."""
+        """Initialise the TmTile."""
         self.settings = settings
         self.settings_map = settings_map
         self.on_change_handler = on_change_handler

--- a/src/amplifyp/gui/views/settings_view.py
+++ b/src/amplifyp/gui/views/settings_view.py
@@ -40,7 +40,7 @@ class SettingsView(ft.ListView):  # type: ignore[misc]
         on_apply: Any | None = None,
         on_reset: Any | None = None,
     ) -> None:
-        """Initialize the SettingsView."""
+        """Initialise the SettingsView."""
         super().__init__(
             expand=True, spacing=20, padding=10, scroll=ft.ScrollMode.ALWAYS
         )
@@ -57,7 +57,7 @@ class SettingsView(ft.ListView):  # type: ignore[misc]
         font_size_micro = self.settings.get("font_size_micro", 10)
         font_size_table_header = self.settings.get("font_size_table_header", 15)
 
-        # Initialize sub-control tiles
+        # Initialise sub-control tiles
         self.replication_tile = ReplicationTile(
             settings=self.settings,
             settings_map=self.settings_map,
@@ -280,7 +280,7 @@ class SettingsView(ft.ListView):  # type: ignore[misc]
         return self.settings.get_replication_settings()
 
     def get_state(self) -> dict[str, Any]:
-        """Get the current settings for serialization."""
+        """Get the current settings for serialisation."""
         self.sync_to_state()
         return self.settings.to_dict()
 

--- a/src/amplifyp/melting.py
+++ b/src/amplifyp/melting.py
@@ -16,7 +16,7 @@
 """Primer melting temperature calculation module.
 
 This module provides functions to calculate the melting temperature (Tm) of
-DNA primers using the Nearest-Neighbor thermodynamics model.
+DNA primers using the Nearest-Neighbour thermodynamics model.
 """
 
 import math
@@ -33,7 +33,7 @@ from .settings import (
 # Keys are dinucleotides (5'->3')
 # Source: SantaLucia, J. (1998). "A unified view of polymer, dumbbell, and
 # oligonucleotide DNA
-# nearest-neighbor thermodynamics". PNAS, 95(4), 1460-1465.
+# nearest-neighbour thermodynamics". PNAS, 95(4), 1460-1465.
 NN_THERMO_DATA: Final[dict[str, tuple[float, float]]] = {
     "AA": (-7900, -22.2),
     "TT": (-7900, -22.2),
@@ -59,7 +59,7 @@ def calculate_tm_santalucia_1998_owczarzy_2008(
 ) -> float:
     """Calculate the melting temperature (Tm) of a primer sequence.
 
-    Uses the Nearest-Neighbor model with SantaLucia 1998 thermodynamic
+    Uses the Nearest-Neighbour model with SantaLucia 1998 thermodynamic
     parameters and salt corrections.
 
     Formula used:
@@ -119,7 +119,7 @@ def calculate_tm_santalucia_1998_owczarzy_2008(
         dh += 2300
         ds += 4.1
 
-    # Nearest neighbor steps
+    # Nearest neighbour steps
     for i in range(n - 1):
         dinuc = seq[i : i + 2]
         if dinuc in NN_THERMO_DATA:
@@ -267,7 +267,7 @@ def calculate_tm_lander_amplify4(
     entr: float = 108.0
     enth: float = 0.0
 
-    # Sum neighbors
+    # Sum neighbours
     # Note: entropy/enthalpy tables in Swift are accessed as [y][x]
     # where x is current base, y is next base.
     for i in range(seq_len - 1):

--- a/src/amplifyp/origin.py
+++ b/src/amplifyp/origin.py
@@ -187,7 +187,7 @@ class Amplify4RevOrigin(ReplicationOrigin):
     """
 
     def __init__(self, target: str, primer: str) -> None:
-        """Initialize an Amplify4RevOrigin object.
+        """Initialise an Amplify4RevOrigin object.
 
         Args:
             target (str): The target DNA sequence. The complement will be used.
@@ -212,7 +212,7 @@ class Amplify4FwdOrigin(ReplicationOrigin):
     """
 
     def __init__(self, target: str, primer: str) -> None:
-        """Initialize an Amplify4FwdOrigin object.
+        """Initialise an Amplify4FwdOrigin object.
 
         Args:
             target (str): The target DNA sequence.

--- a/src/amplifyp/pcr.py
+++ b/src/amplifyp/pcr.py
@@ -42,7 +42,7 @@ class PCR:
         template: DNA,
         settings: ReplicationSettings = GLOBAL_REPLICATION_SETTINGS,
     ):
-        """Initialize a PCR reaction."""
+        """Initialise a PCR reaction."""
         self.template = template
         self.settings = settings
         self.__primers: list[Primer] = []

--- a/src/amplifyp/repliconf.py
+++ b/src/amplifyp/repliconf.py
@@ -240,7 +240,7 @@ class Repliconf:
     Attributes:
         padding_len (int): The length of padding added to the template,
             typically equal to the primer length.
-        primer (Primer): The primer sequence being analyzed.
+        primer (Primer): The primer sequence being analysed.
         template (DNA): The original template DNA sequence.
         template_seq (dict[DNADirection, str]): A dictionary mapping direction
             (FWD/REV) to the processed (padded/complemented) template strings.
@@ -255,7 +255,7 @@ class Repliconf:
         primer: Primer,
         settings: ReplicationSettings = GLOBAL_REPLICATION_SETTINGS,
     ) -> None:
-        """Initialize a Repliconf object.
+        """Initialise a Repliconf object.
 
         Args:
             template (DNA): The template DNA sequence to be searched.
@@ -277,7 +277,7 @@ class Repliconf:
                 template.seq + Nucleotides.GAP * self.padding_len
             ).translate(GLOBAL_COMPLEMENT_TABLE)
         elif template.type == DNAType.CIRCULAR:
-            # Matches existing behavior including 0 case where padding is empty
+            # Matches existing behaviour including 0 case where padding is empty
             padding = (
                 template.seq[-self.padding_len :]
                 if self.padding_len > 0
@@ -336,7 +336,7 @@ class Repliconf:
         i = var.index
 
         if direction:
-            # Optimized reverse slicing: template_seq[end-1:start-1:-1]
+            # Optimised reverse slicing: template_seq[end-1:start-1:-1]
             # This creates only 1 string object instead of 2 (slice then
             # reverse)
             end = i + len(self.primer)
@@ -378,7 +378,7 @@ class Repliconf:
         """
         self.origin_db.clear()
 
-        # Optimization: Pre-calculate constants and lookup tables
+        # Optimisation: Pre-calculate constants and lookup tables
         m = self.settings.match_weight
         S = self.settings.base_pair_scores
         r = self.settings.run_weights

--- a/src/amplifyp/settings.py
+++ b/src/amplifyp/settings.py
@@ -50,7 +50,7 @@ class LengthWiseWeightTbl:
         default_weight: float = 0,
         overrides: dict[int, float] | None = None,
     ) -> None:
-        """Initialize a LengthWiseWeightTbl object.
+        """Initialise a LengthWiseWeightTbl object.
 
         Args:
             default_weight (float, optional): The default weight to use when a
@@ -137,7 +137,7 @@ class BasePairWeightsTbl:
         self.__weight: dict[tuple[str, str], float] = {}
         self.__row_max: dict[str, float] = {}
 
-        # Optimized lookups
+        # Optimised lookups
         self.__matrix: list[list[float]] = [
             [0.0] * len(self.__col) for _ in range(len(self.__row))
         ]
@@ -380,7 +380,7 @@ DEFAULT_PRIMER_DIMER_SYMBOL_THRESHOLD: Final[float] = 10.0
 class ReplicationSettings:
     """A configuration class for replication settings.
 
-    This class aggregates all parameters required for analyzing replication
+    This class aggregates all parameters required for analysing replication
     origins. It includes scoring tables for base pairing and run lengths, as
     well as cutoff thresholds for filtering results.
 

--- a/tests/dna_test.py
+++ b/tests/dna_test.py
@@ -22,7 +22,7 @@ from amplifyp.errors import InvalidDNASequenceError, InvalidDNATypeError
 
 
 def test_dna_init() -> None:
-    """Test the initialization of a DNA object with a given sequence."""
+    """Test the initialisation of a DNA object with a given sequence."""
     dna = DNA("ATCG")
     assert dna.seq == "ATCG"
     assert dna.type == DNAType.LINEAR
@@ -96,7 +96,7 @@ def test_dna_str() -> None:
 
 
 def test_primer_init() -> None:
-    """Test the initialization of a Primer object."""
+    """Test the initialisation of a Primer object."""
     primer = Primer("ATCG")
     assert primer.seq == "ATCG"
     assert primer.type == DNAType.PRIMER

--- a/tests/gui_state_test.py
+++ b/tests/gui_state_test.py
@@ -67,7 +67,7 @@ def test_gui_state_save_load() -> None:
         "settings": settings_state,
     }
 
-    # 4. Serialize (replicating main.py logic)
+    # 4. Serialise (replicating main.py logic)
     def multiline_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
         if "\n" in data:
             return dumper.represent_scalar(
@@ -286,7 +286,7 @@ def test_system_theme_saving_loading() -> None:
     assert settings_view.settings["dark_mode"] == "system"
     assert settings_view.settings["colour_deficient"] is False
 
-    # 2. Serialize / deserialize settings state
+    # 2. Serialise / deserialize settings state
     settings_state = settings_view.get_state()
     new_settings_view = SettingsView(mock_page)
     new_settings_view.set_state(settings_state)

--- a/tests/gui_web_e2e_test.py
+++ b/tests/gui_web_e2e_test.py
@@ -401,7 +401,7 @@ def test_e2e_dimer_alignment(page: Any, serve_app: str, tmp_path: Any) -> None:
     page.locator("flt-semantics-placeholder").first.dispatch_event("click")
 
     # Wait for the primer name input to appear — confirms Pyodide is fully
-    # initialized and the semantics tree is ready. Much more reliable than
+    # initialised and the semantics tree is ready. Much more reliable than
     # a fixed sleep.
     NAME_SEL = 'input[aria-label="New Primer Name"]'
     SEQ_SEL = 'input[aria-label="New Primer Sequence"]'

--- a/tests/input_view_test.py
+++ b/tests/input_view_test.py
@@ -189,7 +189,7 @@ def test_input_view_clear_buttons() -> None:
 def test_input_view_primer_info_panel() -> None:
     """Test that the primer info panel displays correct information.
 
-    Verifies behavior when a primer is focused.
+    Verifies behaviour when a primer is focused.
     """
     mock_page = MagicMock(spec=ft.Page)
     input_data = GUIInput()

--- a/tests/melting_test.py
+++ b/tests/melting_test.py
@@ -85,11 +85,11 @@ def test_salt_dependence() -> None:
     tm_low = calculate_tm_santalucia_1998_owczarzy_2008(Primer(seq), low_salt)
     tm_high = calculate_tm_santalucia_1998_owczarzy_2008(Primer(seq), high_salt)
 
-    # Higher salt should stabilize DNA, increasing Tm
+    # Higher salt should stabilise DNA, increasing Tm
     assert tm_high > tm_low
 
 
-def test_magnesium_stabilization() -> None:
+def test_magnesium_stabilisation() -> None:
     """Test that adding Mg2+ increases Tm."""
     # 50 mM Na+, 0 mM Mg++
     no_mg = replace(GLOBAL_TM_SETTINGS, divalent_salt_conc=0.0)

--- a/tests/origin_test.py
+++ b/tests/origin_test.py
@@ -33,7 +33,7 @@ from amplifyp.settings import ReplicationSettings
 
 
 def test_replication_origin_init() -> None:
-    """Test the initialization of a Origin object with invalid parameters."""
+    """Test the initialisation of a Origin object with invalid parameters."""
     with pytest.raises(ReplicationOriginLengthError):
         ReplicationOrigin(
             target="ATCG", primer="ATC", settings=ReplicationSettings()

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -107,7 +107,7 @@ def test_base_pair_weights_tbl_case_sensitivity() -> None:
         [0.0, 0.0, 0.0, 1.0],
     ]
 
-    # Initialize with lowercase
+    # Initialise with lowercase
     tbl = BasePairWeightsTbl(row, col, weights)
 
     # Check if row() and column() return uppercase (accessing row and col)
@@ -126,7 +126,7 @@ def test_base_pair_weights_tbl_case_sensitivity() -> None:
 
 def test_base_pair_weights_tbl_invalid_chars() -> None:
     """Test BasePairWeightsTbl with invalid characters (code >= 128)."""
-    # The optimized lookup table only supports ASCII (0-127).
+    # The optimised lookup table only supports ASCII (0-127).
     # Characters outside this range should fall back to dictionary lookup
     # or handle gracefully (be ignored in map).
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,10 @@
+[default.extend-identifiers]
+# Flet library API references
+Colors = "Colors"
+CENTER = "CENTER"
+[default.extend-words]
+# Flet library API references
+color = "color"
+
+[files]
+extend-exclude = ["LICENSE"]


### PR DESCRIPTION
- Swap codespell for typos-cli in .pre-commit-config.yaml
- Add typos.toml config: en-gb locale, ignore Flet API refs (Colors, CENTER, color), exclude LICENSE
- Convert all American spellings in source code and tests to British English
- Rename test function test_magnesium_stabilization -> test_magnesium_stabilisation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced spell-checking tool from `codespell` to `typos` (v1.36.0) for improved code quality scanning.
  * Standardized codebase documentation and comments to use consistent British English spellings throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->