### PR TITLE
Fix Windows CI Unicode encoding error

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -65,6 +65,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      PYTHONUTF8: 1
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Set PYTHONUTF8 to 1 for the build-binaries job to force Python to use UTF-8 encoding on Windows, preventing UnicodeEncodeErrors from rich library outputs.