### PR TITLE
Fix visualization logic for wrapped circular amplicons

### DIFF
--- a/src/amplifyp/gui/views/pcr/amplicon_drawing.py
+++ b/src/amplifyp/gui/views/pcr/amplicon_drawing.py
@@ -128,12 +128,16 @@ class DrawnAmplicon:
                 cv.Path(
                     [
                         cv.Path.MoveTo(self.x_start, self.y_pos),
-                        cv.Path.LineTo(self.c_width - self.h_margin, self.y_pos),
+                        cv.Path.LineTo(
+                            self.c_width - self.h_margin, self.y_pos
+                        ),
                         cv.Path.LineTo(
                             self.c_width - self.h_margin,
                             self.y_pos + self.bar_height,
                         ),
-                        cv.Path.LineTo(self.x_start, self.y_pos + self.bar_height),
+                        cv.Path.LineTo(
+                            self.x_start, self.y_pos + self.bar_height
+                        ),
                         cv.Path.Close(),
                     ],
                     paint=amp_paint,
@@ -148,7 +152,9 @@ class DrawnAmplicon:
                         cv.Path.LineTo(
                             self.x_end, self.y_pos + self.bar_height
                         ),
-                        cv.Path.LineTo(self.h_margin, self.y_pos + self.bar_height),
+                        cv.Path.LineTo(
+                            self.h_margin, self.y_pos + self.bar_height
+                        ),
                         cv.Path.Close(),
                     ],
                     paint=amp_paint,

--- a/src/amplifyp/gui/views/pcr/amplicon_drawing.py
+++ b/src/amplifyp/gui/views/pcr/amplicon_drawing.py
@@ -119,27 +119,49 @@ class DrawnAmplicon:
             color=GUIColours.DIAGRAM_BLACK,
             style=ft.PaintingStyle.FILL,
         )
-        if self.amp.circular:
+
+        is_wrapped = self.amp.circular and (self.end_idx < self.start_idx)
+
+        if is_wrapped:
+            # Draw right part (start to end of template)
             canvas.shapes.append(
                 cv.Path(
                     [
-                        cv.Path.MoveTo(self.h_margin, self.y_pos),
-                        cv.Path.LineTo(
-                            self.c_width - self.h_margin, self.y_pos
-                        ),
+                        cv.Path.MoveTo(self.x_start, self.y_pos),
+                        cv.Path.LineTo(self.c_width - self.h_margin, self.y_pos),
                         cv.Path.LineTo(
                             self.c_width - self.h_margin,
                             self.y_pos + self.bar_height,
                         ),
-                        cv.Path.LineTo(
-                            self.h_margin, self.y_pos + self.bar_height
-                        ),
+                        cv.Path.LineTo(self.x_start, self.y_pos + self.bar_height),
                         cv.Path.Close(),
                     ],
                     paint=amp_paint,
                 )
             )
-            label_x = self.h_margin + (self.t_width / 2.0)
+            # Draw left part (start of template to end)
+            canvas.shapes.append(
+                cv.Path(
+                    [
+                        cv.Path.MoveTo(self.h_margin, self.y_pos),
+                        cv.Path.LineTo(self.x_end, self.y_pos),
+                        cv.Path.LineTo(
+                            self.x_end, self.y_pos + self.bar_height
+                        ),
+                        cv.Path.LineTo(self.h_margin, self.y_pos + self.bar_height),
+                        cv.Path.Close(),
+                    ],
+                    paint=amp_paint,
+                )
+            )
+
+            len1 = (self.c_width - self.h_margin) - self.x_start
+            len2 = self.x_end - self.h_margin
+
+            if len1 >= len2:
+                label_x = self.x_start + (len1 / 2.0)
+            else:
+                label_x = self.h_margin + (len2 / 2.0)
         else:
             canvas.shapes.append(
                 cv.Path(
@@ -174,13 +196,13 @@ class DrawnAmplicon:
         )
 
         # Click overlay for the amplicon
-        amp_width = max(
-            10.0,
-            (self.x_end - self.x_start)
-            if not self.amp.circular
-            else (self.c_width - 2 * self.h_margin),
-        )
-        amp_left = self.x_start if not self.amp.circular else self.h_margin
+        if is_wrapped:
+            amp_width = max(10.0, self.c_width - 2 * self.h_margin)
+            amp_left = self.h_margin
+        else:
+            amp_width = max(10.0, self.x_end - self.x_start)
+            amp_left = self.x_start
+
         stack.controls.append(
             ft.GestureDetector(
                 mouse_cursor=ft.MouseCursor.CLICK,


### PR DESCRIPTION
Fix visualization logic for wrapped circular amplicons

When an amplicon wraps around the origin of a circular DNA template,
it should be drawn as two separate segments on the PCR diagram. This
patch fixes the drawing logic in DrawnAmplicon to properly divide the
amplicon path into a right-hand and a left-hand part. It also centers
the label on the larger of the two segments and updates the click overlay.

---
*PR created automatically by Jules for task [8337139897870704389](https://jules.google.com/task/8337139897870704389) started by @fangfufu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circular amplicon drawing so wrapped sequences display correctly across the template boundary.
  * Adjusted the length label placement to stay centered over the visible amplicon segment.
  * Updated the clickable/tappable area to better match what is actually shown on screen for circular and non-wrapped amplicons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->