### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_stable.yml
+++ b/.github/workflows/pr_stable.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [stable]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   test:
     name: Run tests and checks (${{ matrix.os }} - Python ${{ matrix.python-version }})

--- a/.github/workflows/push_dev.yml
+++ b/.github/workflows/push_dev.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [dev]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   test:
     name: Run fast tests and checks

--- a/.github/workflows/push_stable.yml
+++ b/.github/workflows/push_stable.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     name: Build artifacts (${{ matrix.os }})
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/fangfufu/AmplifyP/security/code-scanning/19](https://github.com/fangfufu/AmplifyP/security/code-scanning/19)

Add an explicit `permissions` block to the `build` job in `.github/workflows/push_stable.yml` with the minimum required scope.  
Best single fix without changing functionality: set:

- `contents: read`

under `jobs.build`, alongside `runs-on`/`strategy` fields. This satisfies CodeQL’s requirement and documents least-privilege intent while preserving behavior.

No imports, methods, or dependency changes are needed (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
