### PR TITLE
fix: remove PCR/dimer cache and fix render order

### DIFF
--- a/src/amplifyp/gui/controller.py
+++ b/src/amplifyp/gui/controller.py
@@ -87,6 +87,7 @@ class GUIController:
         self.notification_helper: NotificationHelper = cast(
             NotificationHelper, None
         )
+        self.input_view_dirty = False
 
     def initialise(self) -> None:
         """Configure page setup, window events, views, and custom layout."""
@@ -397,9 +398,15 @@ class GUIController:
     ) -> None:
         """Handle system brightness shifts."""
         self.apply_theme()
-        self.input_view.update_ui()
-        self.settings_view.update_ui()
         active_view = self.view_container.content
+        if active_view == self.input_view:
+            self.input_view.update_ui()
+        else:
+            self.input_view_dirty = True
+
+        if active_view == self.settings_view:
+            self.settings_view.update_ui()
+
         if active_view == self.pcr_view:
             self.pcr_view.run_pcr(keep_cards=True)
         elif active_view == self.dimers_view:
@@ -498,7 +505,10 @@ class GUIController:
         active_view = self.view_container.content
         if active_view == self.input_view:
             self.input_view.update_ui()
-        elif active_view == self.settings_view:
+        else:
+            self.input_view_dirty = True
+
+        if active_view == self.settings_view:
             self.settings_view.update_ui()
 
         self.update_pcr_button_state()
@@ -627,13 +637,15 @@ class GUIController:
             _e: The event that triggered the view switch (unused).
             view: The Flet control to display as the new view.
         """
+        if view == self.input_view and self.input_view_dirty:
+            self.input_view.update_ui()
+            self.input_view_dirty = False
+
         self.view_container.content = view
         is_input = view == self.input_view
         self.visible_save_btn_control.visible = is_input
         self.visible_load_btn_control.visible = is_input
         self.visible_header_divider.visible = is_input
-        if hasattr(view, "update_ui"):
-            view.update_ui()
 
         if view == self.input_view:
             self.page.on_resize = self.input_view._handle_resize
@@ -641,9 +653,6 @@ class GUIController:
             self.page.on_resize = self.pcr_view._handle_resize
         else:
             self.page.on_resize = None
-
-        if hasattr(view, "update_ui"):
-            view.update_ui()
 
         self.page.update()
 

--- a/src/amplifyp/gui/controller.py
+++ b/src/amplifyp/gui/controller.py
@@ -425,11 +425,6 @@ class GUIController:
         self.switch_view(e, self.pcr_view)
         if not self.pcr_view.run_pcr():
             self.switch_view(e, self.input_view)
-        if self.pcr_button_ref.current:
-            self.pcr_button_ref.current.text = "PCR"
-        if self.visible_pcr_button_ref.current:
-            self.visible_pcr_button_ref.current.text = "PCR"
-        self.page.update()
 
     def on_dimers_click(self, e: ft.ControlEvent) -> None:
         """Handle dimers click: switch view then run analysis."""
@@ -437,7 +432,6 @@ class GUIController:
         self.switch_view(e, self.dimers_view)
         if not self.dimers_view.run_analysis():
             self.switch_view(e, self.input_view)
-        self.page.update()
 
     def update_pcr_button_state(self, sync: bool = True) -> None:
         """Enable PCR and dimers buttons only if input is valid."""

--- a/src/amplifyp/gui/controller.py
+++ b/src/amplifyp/gui/controller.py
@@ -399,32 +399,44 @@ class GUIController:
         self.apply_theme()
         self.input_view.update_ui()
         self.settings_view.update_ui()
-        if self.pcr_view.diagram_panel.diagram_container.visible:
+        active_view = self.view_container.content
+        if active_view == self.pcr_view:
             self.pcr_view.run_pcr(keep_cards=True)
-        if len(self.dimers_view.result_list.controls) > 0:
+        elif active_view == self.dimers_view:
             self.dimers_view.run_analysis()
         self.page.update()
 
     def on_pcr_click(self, e: ft.ControlEvent) -> None:
-        """Handle PCR click: run PCR and switch view if successful."""
-        if self.pcr_view.run_pcr():
-            self.switch_view(e, self.pcr_view)
-            if self.pcr_button_ref.current:
-                self.pcr_button_ref.current.text = "PCR"
-            if self.visible_pcr_button_ref.current:
-                self.visible_pcr_button_ref.current.text = "PCR"
-            self.page.update()
+        """Handle PCR click: switch view then run PCR.
+
+        The view is switched first so the diagram canvas renders
+        while the PCR view is the active content.  This avoids
+        Flet's diff algorithm marking canvas shapes as 'already
+        sent' before the view becomes visible.
+        """
+        self.update_pcr_button_state(sync=True)
+        self.switch_view(e, self.pcr_view)
+        if not self.pcr_view.run_pcr():
+            self.switch_view(e, self.input_view)
+        if self.pcr_button_ref.current:
+            self.pcr_button_ref.current.text = "PCR"
+        if self.visible_pcr_button_ref.current:
+            self.visible_pcr_button_ref.current.text = "PCR"
+        self.page.update()
 
     def on_dimers_click(self, e: ft.ControlEvent) -> None:
-        """Handle dimers click: run analysis and switch view if successful."""
-        if self.dimers_view.run_analysis():
-            self.switch_view(e, self.dimers_view)
-            self.page.update()
+        """Handle dimers click: switch view then run analysis."""
+        self.update_pcr_button_state(sync=True)
+        self.switch_view(e, self.dimers_view)
+        if not self.dimers_view.run_analysis():
+            self.switch_view(e, self.input_view)
+        self.page.update()
 
     def update_pcr_button_state(self, sync: bool = True) -> None:
         """Enable PCR and dimers buttons only if input is valid."""
         if sync:
             self.input_view.sync_to_state()
+
         has_template = bool(self.input_data.template.strip())
         active_primers = self.input_data.get_active_primers()
         has_enough_primers = len(active_primers) >= 1

--- a/src/amplifyp/gui/views/dimer/dimer_view.py
+++ b/src/amplifyp/gui/views/dimer/dimer_view.py
@@ -17,7 +17,6 @@
 
 import logging
 import traceback
-from typing import TYPE_CHECKING, Any
 
 import flet as ft
 
@@ -30,9 +29,6 @@ from amplifyp.gui.util import clean_sequence, show_error_dialog
 from amplifyp.gui.views.dimer.dimer_card import DimerCard
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from amplifyp.dimer import PrimerDimer
 
 
 class DimerView(ft.Column):  # type: ignore[misc]
@@ -49,10 +45,6 @@ class DimerView(ft.Column):  # type: ignore[misc]
         self.app_page = page
         self.input_data = input_data if input_data is not None else GUIInput()
         self.settings = settings if settings is not None else GUISettings()
-        self._cached_dimers: list[PrimerDimer] | None = None
-        self._cached_state_key: tuple[dict[str, Any], dict[str, Any]] | None = (
-            None
-        )
 
         self.result_list = ft.ListView(
             expand=True, spacing=10, scroll=ft.ScrollMode.ALWAYS
@@ -66,28 +58,16 @@ class DimerView(ft.Column):  # type: ignore[misc]
         self.result_list.controls.clear()
         success = True
         try:
-            current_state_key = (
-                self.input_data.to_dict(),
-                self.settings.to_dict(),
-            )
-            if (
-                self._cached_state_key == current_state_key
-                and self._cached_dimers is not None
-            ):
-                dimers = self._cached_dimers
-            else:
-                pd_settings = self.settings.get_primer_dimer_settings()
-                generator = PrimerDimerGenerator(settings=pd_settings)
-                primers = self.input_data.get_active_primers()
-                for p in primers:
-                    name = p["name"]
-                    seq = clean_sequence(p["seq"])
-                    generator.add_primer(Primer(sequence=seq, name=name))
+            pd_settings = self.settings.get_primer_dimer_settings()
+            generator = PrimerDimerGenerator(settings=pd_settings)
+            primers = self.input_data.get_active_primers()
+            for p in primers:
+                name = p["name"]
+                seq = clean_sequence(p["seq"])
+                generator.add_primer(Primer(sequence=seq, name=name))
 
-                generator.analyse_primers()
-                dimers = generator.primer_dimers
-                self._cached_dimers = dimers
-                self._cached_state_key = current_state_key
+            generator.analyse_primers()
+            dimers = generator.primer_dimers
 
             if not dimers:
                 self.result_list.controls.append(
@@ -110,11 +90,11 @@ class DimerView(ft.Column):  # type: ignore[misc]
                     self.result_list.controls.append(
                         ft.Container(
                             content=ft.Text(
-                                f"Warning: {num_dimers} primer dimers "
-                                "detected. Only the top "
-                                f"{MAX_DIMERS_RENDER} strongest binding "
-                                "dimers are displayed to prevent "
-                                "UI freeze.",
+                                f"Warning: {num_dimers} primer "
+                                "dimers detected. Only the top "
+                                f"{MAX_DIMERS_RENDER} strongest "
+                                "binding dimers are displayed to "
+                                "prevent UI freeze.",
                                 color=GUIColours.ERROR_RED,
                                 weight=ft.FontWeight.BOLD,
                             ),

--- a/src/amplifyp/gui/views/dimer/dimer_view.py
+++ b/src/amplifyp/gui/views/dimer/dimer_view.py
@@ -17,10 +17,11 @@
 
 import logging
 import traceback
+from typing import Any
 
 import flet as ft
 
-from amplifyp.dimer import PrimerDimerGenerator
+from amplifyp.dimer import PrimerDimer, PrimerDimerGenerator
 from amplifyp.dna import Primer
 from amplifyp.gui.colours import GUIColours
 from amplifyp.gui.settings import MAX_DIMERS_RENDER, GUISettings
@@ -45,6 +46,10 @@ class DimerView(ft.Column):  # type: ignore[misc]
         self.app_page = page
         self.input_data = input_data if input_data is not None else GUIInput()
         self.settings = settings if settings is not None else GUISettings()
+        self._cached_dimers: list[PrimerDimer] | None = None
+        self._cached_state_key: tuple[dict[str, Any], dict[str, Any]] | None = (
+            None
+        )
 
         self.result_list = ft.ListView(
             expand=True, spacing=10, scroll=ft.ScrollMode.ALWAYS
@@ -58,16 +63,28 @@ class DimerView(ft.Column):  # type: ignore[misc]
         self.result_list.controls.clear()
         success = True
         try:
-            pd_settings = self.settings.get_primer_dimer_settings()
-            generator = PrimerDimerGenerator(settings=pd_settings)
-            primers = self.input_data.get_active_primers()
-            for p in primers:
-                name = p["name"]
-                seq = clean_sequence(p["seq"])
-                generator.add_primer(Primer(sequence=seq, name=name))
+            current_state_key = (
+                self.input_data.to_dict(),
+                self.settings.to_dict(),
+            )
+            if (
+                self._cached_state_key == current_state_key
+                and self._cached_dimers is not None
+            ):
+                dimers = self._cached_dimers
+            else:
+                pd_settings = self.settings.get_primer_dimer_settings()
+                generator = PrimerDimerGenerator(settings=pd_settings)
+                primers = self.input_data.get_active_primers()
+                for p in primers:
+                    name = p["name"]
+                    seq = clean_sequence(p["seq"])
+                    generator.add_primer(Primer(sequence=seq, name=name))
 
-            generator.analyse_primers()
-            dimers = generator.primer_dimers
+                generator.analyse_primers()
+                dimers = generator.primer_dimers
+                self._cached_dimers = dimers
+                self._cached_state_key = current_state_key
 
             if not dimers:
                 self.result_list.controls.append(

--- a/src/amplifyp/gui/views/pcr/pcr_diagram_panel.py
+++ b/src/amplifyp/gui/views/pcr/pcr_diagram_panel.py
@@ -120,7 +120,7 @@ class PCRDrawingPanel(ft.Column):  # type: ignore[misc]
         Clears all shapes, hides the diagram container and divider,
         and resets the stack to contain only the canvas.
         """
-        self.diagram_canvas.shapes.clear()
+        self.diagram_canvas.shapes = []
         self.diagram_stack.controls.clear()
         self.diagram_stack.controls.append(self.diagram_canvas)
         self.diagram_container.visible = False
@@ -200,6 +200,10 @@ class PCRDrawingPanel(ft.Column):  # type: ignore[misc]
             amplicons=amplicons,
             v_frag_start=v_frag_start,
         )
+
+        # Force a new list reference for canvas shapes to trigger
+        # Flet change detection
+        self.diagram_canvas.shapes = list(self.diagram_canvas.shapes)
 
     def _draw_template_baseline(
         self,

--- a/src/amplifyp/gui/views/pcr/pcr_view.py
+++ b/src/amplifyp/gui/views/pcr/pcr_view.py
@@ -53,6 +53,10 @@ class PCRView(ft.Column):  # type: ignore[misc]
 
         self.input_data = input_data if input_data is not None else GUIInput()
         self.settings = settings if settings is not None else GUISettings()
+        self._cached_pcr: PCR | None = None
+        self._cached_state_key: tuple[dict[str, Any], dict[str, Any]] | None = (
+            None
+        )
 
         self.result_list = ft.ListView(
             expand=True, spacing=10, scroll=ft.ScrollMode.ALWAYS
@@ -116,7 +120,19 @@ class PCRView(ft.Column):  # type: ignore[misc]
         saved_cards = self._reset_pcr_ui(keep_cards)
         success = True
         try:
-            pcr = self._execute_pcr_simulation()
+            current_state_key = (
+                self.input_data.to_dict(),
+                self.settings.to_dict(),
+            )
+            if (
+                self._cached_state_key == current_state_key
+                and self._cached_pcr is not None
+            ):
+                pcr = self._cached_pcr
+            else:
+                pcr = self._execute_pcr_simulation()
+                self._cached_pcr = pcr
+                self._cached_state_key = current_state_key
             num_amplicons = len(pcr.amplicons)
 
             if num_amplicons == 0:

--- a/src/amplifyp/gui/views/pcr/pcr_view.py
+++ b/src/amplifyp/gui/views/pcr/pcr_view.py
@@ -53,10 +53,6 @@ class PCRView(ft.Column):  # type: ignore[misc]
 
         self.input_data = input_data if input_data is not None else GUIInput()
         self.settings = settings if settings is not None else GUISettings()
-        self._cached_pcr: PCR | None = None
-        self._cached_state_key: tuple[dict[str, Any], dict[str, Any]] | None = (
-            None
-        )
 
         self.result_list = ft.ListView(
             expand=True, spacing=10, scroll=ft.ScrollMode.ALWAYS
@@ -97,17 +93,17 @@ class PCRView(ft.Column):  # type: ignore[misc]
 
     @property
     def diagram_stack(self) -> ft.Stack:
-        """Shortcut property to the diagram stack for test compatibility."""
+        """Shortcut property to the diagram stack for test compat."""
         return self.diagram_panel.diagram_stack
 
     @property
     def diagram_container(self) -> ft.Container:
-        """Shortcut property to the diagram container for test compatibility."""
+        """Shortcut property to the diagram container for test compat."""
         return self.diagram_panel.diagram_container
 
     @property
     def divider(self) -> ft.GestureDetector:
-        """Shortcut property to the divider resizer for test compatibility."""
+        """Shortcut property to the divider resizer for test compat."""
         return self.diagram_panel.divider
 
     def _handle_resize(self, e: ft.ControlEvent) -> None:
@@ -120,19 +116,7 @@ class PCRView(ft.Column):  # type: ignore[misc]
         saved_cards = self._reset_pcr_ui(keep_cards)
         success = True
         try:
-            current_state_key = (
-                self.input_data.to_dict(),
-                self.settings.to_dict(),
-            )
-            if (
-                self._cached_state_key == current_state_key
-                and self._cached_pcr is not None
-            ):
-                pcr = self._cached_pcr
-            else:
-                pcr = self._execute_pcr_simulation()
-                self._cached_pcr = pcr
-                self._cached_state_key = current_state_key
+            pcr = self._execute_pcr_simulation()
             num_amplicons = len(pcr.amplicons)
 
             if num_amplicons == 0:
@@ -186,7 +170,7 @@ class PCRView(ft.Column):  # type: ignore[misc]
         return saved_cards
 
     def _execute_pcr_simulation(self) -> PCR:
-        """Clean sequences, build DNA and PCR objects, and run simulation."""
+        """Clean sequences, build DNA/PCR objects, run simulation."""
         from amplifyp.gui.util import clean_sequence
 
         clean_template = clean_sequence(self.input_data.template)
@@ -245,7 +229,7 @@ class PCRView(ft.Column):  # type: ignore[misc]
         self.app_page.update()
 
     def _show_amplicon_dialog(self, amp: "Amplicon") -> None:
-        """Show details card of the selected amplicon below the overview map."""
+        """Show details card of the selected amplicon."""
         card_id = (
             f"amplicon_{amp.fwd_origin.name}_{amp.rev_origin.name}_"
             f"{amp.start.index}_{amp.end.index}"

--- a/tests/examples/save_states/README.md
+++ b/tests/examples/save_states/README.md
@@ -6,5 +6,7 @@ The original of the files in this folder:
   `Amplify4/Amplify4.app/Contents/Resources/Amplify Sample Target.rtf`
 - `amplify_4_full_example.yaml` was created by loading in
   `amplify_4_all_primers.tsv` and `amplify_4_template.txt` and saving the state.
+- `amplify_4_full_example_all_valid.yaml` was created from
+  `amplify_4_full_example.yaml` by removing all the duplicated primers.
 - `simple.yaml` was created from Amplify 4's samples.
 - `overlapping_primers.yaml` contains primers which are overlapping.

--- a/tests/examples/save_states/amplify_4_full_example_all_valid.yaml
+++ b/tests/examples/save_states/amplify_4_full_example_all_valid.yaml
@@ -1,0 +1,692 @@
+input:
+  template: |-
+    CATGATGAAATAACATAAGGTGGTCCCGTCGAAAGCCGAAGCGCAGAGCTGTCATACTCGAAGGCAGCAGCGACCTTCAT
+    CTCGTCGAAAGCGAGTACGCAAAGCTTGTCGGCGTCATCAACTCCATCACTGTCCATTAGGTCTATGACCACATCCAAAC
+    ATCCTCTTTTTATGTCCACATCTGATAACCATCTGTACAAAGTCGTACGACTGGGCAAAGGAAATCCTTTTTTGTACAGA
+    TGGTTATACGCTCGAGGGCCTGCGGTGTGGAGACAAATAGCTGTAGAAATGTCGTCGGAATTGAACGTAGCTCTTTGTCC
+    ACCATTCTTCAGTATCCGTATCTGCGTGTCCGTGAAGATTTTGCGTAGAGACTCCTCCAACTGTTGAGACTCCCTCAGCT
+    GCTGCTCTAAACGACGCATTTCGTACTCCAAAGTACGAATTTTTTCCCTCAAGCTCTTATTTTCATTAAACAATGAACAG
+    GACCTAACGCACAGTCACGTTATTGTTTACATAAATGATTTTTTTTACTATTCAAACTTACTCTGTTTGTGTACTCCCAC
+    TGGTATAGCCTTCTTTTATCTTTTCTGGTTCAGGCTCTATCACTTTACTAGGTACGGCATCTGCGTTGAGTCGCCTCCTT
+    TTAAATGTCTGACCTTTTGCAGGTGCAGCCTTCCACTGCGAATCATTAAAGTGGGTATCACAAATTTGGGAGTTTTCACC
+    AAGGCTGCACCCAAGGCTCTGCTCCCACAATTTTCTCTTAATAGCACACTTCGGCACGTGAATTAATTTTACTTTTTTNT
+    TCCAGTCACAGCTTTGCAGCTAAAATTTGCAATATTTCATTTTTTTTTATTCCACGTAAGGGTTAATGTTTTCAAAAAAA
+    AATTCGTCCGCACACAACCTTTCCTCTCAACAAGCAAACGTGCACTGAATTTAAGTGTATACTTCGGTAATGATATTGTT
+    TACGAGCCAAGCGACTATGTCCAACTGGCTATTGTTCGTGGTCTAAAAAAATCGTGGAAGCAGCCAGTTTTTTTCGATTT
+    TAATACCCGAATGGACCCGGATACTCTTAACAATATATTAAGGAAACTGCATAGGAAAGGATATTTAGTAGTTGCTATTG
+    TATCCGATTTAGGTACCGGAAACCAAAAGCTATGGACAGAGCTCGGTATATCAGAATGTAAGTTTCGTATATTACAAAAA
+    TCAGATAATCCTTGAAATTCCATTTTTTAGCAAAAACCTGGTTTAGCCATCCTGCAGATGACCATTTAAAGATTTTCGTT
+    TTTTCGGATACGCCACATTTAATTAAGTTAGTCCGTAACCACTATGTGGATTCCGGATTAACAATAAATGGGAAAAAATT
+    AACAAAAAAAACAATTCAGGAGGCACTTCATCTTTGCAACAAGTCCGATCTGTCTATCCTCTTTAAAATTAATGAAAATC
+    ACATTAATGTTCGATCGCTCGCAAAACAGAAGGTTAAATTGGCTACCCAGCTGTTTTCGAATACCACCGCTAGCTCGATC
+    AGACGCTGCTATTCATTGGGGTATGACATTGAAAATGCCACCGAAACTGCGGACTTCTTCAAATTGATGAATGATTGGTT
+    CGACATTTTTAATTCTAAATTGTCCACATCCAATTGCATTGAGTGCTCGCAACCTTATGGCAAGCAGTTGGATATACAGA
+    ATGATATTTTGAATCGAATGTCGGAAATTATGCGAACAGGAATTCTGGATAAACCCAAAAGGCTCCCATTTCAAAAAGGT
+    ATCATTGTGAATAATGCTTCGCTTGATGGCTTGTATAAATATTTGCAAGAAAACTTCAGTATGCAATACATATTAACAAG
+    CCGTCTCAACCAAGACATTGTGGAGCATTTTTTTGGCAGCATGCGATCGAGAGGTGGACAATTCGACCATCCCACTCCAC
+    TGCAGTTTAAGTATAGGTTAAGAAAATATATAATAGGTATGACAAATTTAAAAGAATGCGTAAACAAAAATGTAATTCCA
+    TGATTTATAATTGTTTAATGTTTAGCTATATGTTTCAGGAAAGTTTCAGTTGAGAATGTAGGTAGTTATGTGCTGTCTAT
+    TGTGTTTTGTCTTTTATCTGTTTCTTTTCATTTTATTATTTAATCATTATCCTTTTGCTTATCCAGCCAGGAATACAGAA
+    ATGTTAAGAAATTCGGGAAATATCGAAGAGGACAACTCTGAAAGCTGGCTTAATTTAGATTTCAGTTCTAAAGAAAACGA
+    AAATAAAAGTAAAGATGATGAGCCTGTCGATGATGAGCCTGTCGATGAGATGTTAAGCAATATAGATTTCACCGAAATGG
+    ATGAGTTGACGGAGGATGCGATGGAATATATCGCGGGCTATGTCATTAAAAAATTGAGAATCAGTGACAAAGTAAAAGAA
+    AAAAGAGACATCCACTTAACGTATGCTTGCAATAAGTGCGAGTGAAAGGAATAGTATTCTGAGTGTCGTATTGAGTCTGA
+    GTGAGACAGCGATATGATTGTTGATTAACCCTTAGCATGTCCGTGGGGTTTGAATTAACTCATAATATTAATTAGACGAA
+    ATTATTTTTAAAGTTTTATTTTTAATAATTTGGAGTTTCCAATTAACTTTTGTTTTTGATTTTTAATTTCAATTTTTTTG
+    TTGAAGTACTTAATTCTAAAATATATTCTAATTTTAAAATAAAAAGATTTTACTTGTTTATCAACATCGACGTTTCGCGC
+    TGCTAATATTAATTTTTCCTTTACATTATTTGTAATTTCAAAATTATTATTATTTGTATAATGCAAAAAAATACATTCTA
+    GCTCTTTTAACTTCTCTTGAAATTTTTCGGACGGCTTAATAAGTCCGCCGTGAGACACCTCGTCGACGTATGTAAATGTC
+    AAAGCCGACGGGACCACCTTATGTTATTTCATCATG
+  template_circular: false
+  primers:
+  - name: sn-hot
+    seq: TTCATTCCcactggagCATG
+    active: true
+  - name: anch-2
+    seq: GATCGTAGCGTCACAAGTACCGAT
+    active: true
+  - name: sn-1000
+    seq: AGCAGAGCGCGCGCTGCTAG
+    active: true
+  - name: anch-1
+    seq: ATCGGTACTTGTGACGCTAC
+    active: true
+  - name: sn+6450
+    seq: TTTCAACGATATGCACGATG
+    active: true
+  - name: sn+3900>
+    seq: CAATGGCCCGCGTTGACTTC
+    active: true
+  - name: Nest-a
+    seq: acataaggtggtccCATG
+    active: true
+  - name: '2554'
+    seq: GCAGCGCGAAACGTCGATGT
+    active: true
+  - name: '293'
+    seq: GTGGGTATCACAAATTTGGG
+    active: true
+  - name: 11bp
+    seq: ATTAACCCTTA
+    active: true
+  - name: yellow
+    seq: GCCAAAGTGTGTTGGC
+    active: true
+  - name: '757'
+    seq: GGATTTCCTTTGCCCAGTCG
+    active: true
+  - name: '776'
+    seq: CGACTGGGCAAAGGAAATCC
+    active: true
+  - name: D50-rit
+    seq: CAGATGTGGACATAAAAAGACAAT
+    active: true
+  - name: D50-lft
+    seq: TTTCCTTTACATTATTGTCT
+    active: true
+  - name: sn+4000
+    seq: AACACACCCGCCGGTCCAAG
+    active: true
+  - name: '2816'
+    seq: GAGTGTCGTATTGAGTCTGAG
+    active: true
+  - name: '90'
+    seq: GAAAGGTTGTGTGCGGACGA
+    active: true
+  - name: D2-3
+    seq: CATTTCTGTATTCCTGGCTA
+    active: true
+  - name: 108 (a.k.a. 3312)
+    seq: CGTCCGCACACAACCTTTCC
+    active: true
+  - name: '171'
+    seq: TGCTGCAAAGCTGTGACTGG
+    active: true
+  - name: '1471'
+    seq: TGGCTACCCAGCTGTTTTCG
+    active: true
+  - name: '1514'
+    seq: TCTGATCGAGCTAGCGGTGG
+    active: true
+  - name: '1054'
+    seq: TATCCGGGTCCATTCGGGTA
+    active: true
+  - name: 2785 (a.k.a. 3313)
+    seq: TCGCTGTCTCACTCAGACTC
+    active: true
+  - name: whitetowardP3
+    seq: GTCGGCTACTCCTTGCGTCG
+    active: true
+  - name: '763'
+    seq: CCTTTGCCCAGTCGTACGAC
+    active: true
+  - name: '1627'
+    seq: GCATTGAGTGCTCGCAACCT
+    active: true
+  - name: '1569'
+    seq: AGAAGTCCGCAGTTTCGGTG
+    active: true
+  - name: '35'
+    seq: GCCGAAGCTTACCGAAGTAT
+    active: true
+  - name: '2857'
+    seq: CGTATGCTTGCAATAAGTGC
+    active: true
+  - name: lacZ
+    seq: GCTGCAAGGCGATTAAGTTG
+    active: true
+  - name: w11<-30
+    seq: CGCAGTCGGCTGATCTGTGT
+    active: true
+  - name: KP
+    seq: ATCAACATCGACGTTTCCAC
+    active: true
+  - name: hobo3
+    seq: GGGGATCCTTGTGGGTATACCGTT
+    active: true
+  - name: hobo4
+    seq: GGGGATCCAGTTACTGGCTTTGGG
+    active: true
+  - name: G6A
+    seq: CTTCGGTTCCGCTCGCTTCG
+    active: true
+  - name: P188
+    seq: CTCAGCTGTGACGGAGTCACAGCTTTGCAGCA
+    active: true
+  - name: P2735
+    seq: CCGTCACAGCTGAGTTAATTCAAACCCCACG
+    active: true
+  - name: 17C-1
+    seq: CTGGATCCCAATCCGCATCGAA
+    active: true
+  - name: 17C-4490
+    seq: CTGGATCCCCACCGATCACTGTTC
+    active: true
+  - name: whitetowardP5
+    seq: GGTCATCCTGGAGACGC
+    active: true
+  - name: '414'
+    seq: GGCTATACCAGTGGGAGTAC
+    active: true
+  - name: '594'
+    seq: CTCCCTCAGCTGCTGCTCTA
+    active: true
+  - name: '954'
+    seq: CGAGCCAAGCGACTATGTCC
+    active: true
+  - name: '1864'
+    seq: TTGGCAGCATGCGATCGAGA
+    active: true
+  - name: '1918'
+    seq: AACTGCAGTGGAGTGGGATG
+    active: true
+  - name: '2316'
+    seq: GTTGACGGAGGATGCGATGG
+    active: true
+  - name: '2449'
+    seq: CGGACGGCTTAATAAGTCCG
+    active: true
+  - name: '2767'
+    seq: CCTTAGCATGTCCGTGGGGT
+    active: true
+  - name: '12'
+    seq: AACATAAGGTGGTCCCGTCG
+    active: true
+  - name: white1562->1582
+    seq: GGCAAAACGATTGCCGAATTG
+    active: true
+  - name: P-out
+    seq: CCTTATGTTATTTCATCAT
+    active: true
+  - name: T32
+    seq: ACATAAGGTGGTCCCGTCGT
+    active: true
+  - name: J75only
+    seq: ATGTTTAGCTATAGGTGAGG
+    active: true
+  - name: 589 T7 Pro
+    seq: GGTACCTAATACGACTCACTATAGGGAGTCTCAACAG
+    active: true
+  - name: KP6D
+    seq: GACTGCGGCTGTACAAATGC
+    active: true
+  - name: TR1H
+    seq: CGGCCGAATTCGACCG
+    active: true
+  - name: HR1T
+    seq: CGGTCGAATTCGGCCG
+    active: true
+  - name: to detect 45-bp Y/Z junction
+    seq: AGTCCCATATTCCGTGCTGC
+    active: true
+  - name: HP6.1
+    seq: AGCTTTGCGTACTCGCAAAT
+    active: true
+  - name: sn-2450
+    seq: AAGCTTTCCAGCTGCCCTTC
+    active: true
+  - name: sn+2000
+    seq: AATACTCTACCGAGTCGCAG
+    active: true
+  - name: sn+1000
+    seq: CTGGAAGTAGAGATGGTCGC
+    active: true
+  - name: Nest-b
+    seq: TCGACGggaccaccCATG
+    active: true
+  - name: Nest-c
+    seq: TGTTATTTCATCATGggacc
+    active: true
+  - name: Nest-d
+    seq: TGTTATTTCATCATGggtgg
+    active: true
+  - name: BC+
+    seq: AGCCCACCTCCGGACTGGAC
+    active: true
+  - name: '2948'
+    seq: ATGCCTGGCACAATATGGAC
+    active: true
+  - name: A-
+    seq: catattgtgccaggcatagg
+    active: true
+  - name: A88.1bp
+    seq: CATGATGAAATAACATATGATG
+    active: true
+  - name: '2949'
+    seq: CTTGCCTTTCGgTCGCCGCA
+    active: true
+  - name: '4488'
+    seq: CTGCGGCGAcCGAAAGGCAA
+    active: true
+  - name: B41.1bp
+    seq: CATGATGAAATAACTCTT
+    active: true
+  - name: B42.1bp
+    seq: CTACGTGGGTCTGGCCCAAG
+    active: true
+  - name: B7.1bp
+    seq: GGCCCATGATGAAATATTGT
+    active: true
+  - name: BC-
+    seq: AGGTGTTCCCTGGCCGTTAG
+    active: true
+  - name: BCD
+    seq: AGGTGTTGGCCGTTGTGCCC
+    active: true
+  - name: to add Bgl site
+    seq: ACGTaGaTCTGGCCATTCTC
+    active: true
+  - name: BglG
+    seq: GGCCAGATCTACGTAGTCC
+    active: true
+  - name: bif16
+    seq: ataaccatctatacaa
+    active: true
+  - name: BPd
+    seq: GGATATTTAGTAGTTGcCCAC
+    active: true
+  - name: BPg
+    seq: TTAGCATGTCCGTGGgCAAC
+    active: true
+  - name: '4489'
+    seq: CTGTGGCGgTCCTGGCTGTC
+    active: true
+  - name: '4490'
+    seq: ACAGCCAGGAcCGCCACAGG
+    active: true
+  - name: CaS Rt
+    seq: CGCAGCGGCGAAAGAGACGG
+    active: true
+  - name: CasRt2
+    seq: AAGAGATAGCGGACGCAGCG
+    active: true
+  - name: CasRt3
+    seq: ACTAGAATTCGAGCTCGCCC
+    active: true
+  - name: w1not
+    seq: TGGGTGTTTGCTGCCTCCGC
+    active: true
+  - name: cd-
+    seq: TAAAGTCGACTTCGGGCCTC
+    active: true
+  - name: cd2+
+    seq: TGCAGATGGTTGCCATCTTG
+    active: true
+  - name: cd2-
+    seq: TCAAGATGGCAACCATCTGC
+    active: true
+  - name: '2950'
+    seq: GATGATtGGACTGCGGGCCG
+    active: true
+  - name: '2951'
+    seq: CCGCAGTCCaATCATCGGAT
+    active: true
+  - name: D0-50C
+    seq: GCAAACGCAAACTCAATCGC
+    active: true
+  - name: D1-50C
+    seq: AATCACAGCTCCCTTGGTGC
+    active: true
+  - name: D2-
+    seq: AGTCCAATCATCGGATAGGC
+    active: true
+  - name: D2-50C
+    seq: ACGTCGTTGGTTCTCGTTGC
+    active: true
+  - name: D2a
+    seq: CTCCTCCTCCTGGCACTTGT
+    active: true
+  - name: D2b
+    seq: TCTATATATTGCGCTCTGCAC
+    active: true
+  - name: D3-50C
+    seq: GTAGGCCAACCAATTTGGAG
+    active: true
+  - name: D4-50C
+    seq: CTGACTGTTGGCGATAAGAA
+    active: true
+  - name: D4a-50C
+    seq: GACGCTTGGCACGGAACTATTCA
+    active: true
+  - name: D4d-50C
+    seq: AGACGACACTAGGGGCGCAT
+    active: true
+  - name: 50C 5 outward
+    seq: CTAACGAGCAAAATCACTGC
+    active: true
+  - name: DEG
+    seq: CCATTTGAGGTATACTGGCACCG
+    active: true
+  - name: ordered 18 January 1994
+    seq: TTAAATCGGCTGCCATGTGC
+    active: true
+  - name: DL6
+    seq: AAGAGAGAATGCTTTAGTCG
+    active: true
+  - name: DL7
+    seq: ACCGATGGAAGCTGAGCGTG
+    active: true
+  - name: DL8
+    seq: TCAAGAGCATCAGCATCGAC
+    active: true
+  - name: DocD1
+    seq: TGCTATTCTTCACATCTGCC
+    active: true
+  - name: docD2
+    seq: TGCCTGTTGTTCAACGCAAT
+    active: true
+  - name: DocG
+    seq: TTAAGTACTACCTGTAGCCC
+    active: true
+  - name: '2952'
+    seq: GTCTGCTGATCAACCAATGG
+    active: true
+  - name: '2955'
+    seq: CCATTGGTTgATCAGCAGAC
+    active: true
+  - name: ECO+
+    seq: TCCGGGTCCTCGCATATCTG
+    active: true
+  - name: ECO-
+    seq: GATATGCGAGGACCCGGAAG
+    active: true
+  - name: ef+
+    seq: GGTTGTCGTACCTCTCATGG
+    active: true
+  - name: '4491'
+    seq: ACGTGGGTCTaGCCATTCTCATCGTGAGCTTCCGGGTaCTCGCATATCT
+    active: true
+  - name: '4492'
+    seq: ATGAGAATGGCtAGACCCACGTAGTCCAGCGGCAGgTCGGCGGCGGAGA
+    active: true
+  - name: ordered 14 February 1994
+    seq: ACGTGGGTCTaGCCATTCTC
+    active: true
+  - name: F6o-
+    seq: GAATGGCtAGACCCACGTAGTCC
+    active: true
+  - name: fg-
+    seq: AAACACGATGGTAATAATGG
+    active: true
+  - name: '4493'
+    seq: GCCGACATAgATCCGAAATAACTG
+    active: true
+  - name: '2953'
+    seq: CAGTTATTTCGGATcTATGTCGGC
+    active: true
+  - name: G0-50C
+    seq: GCCATCCTCCAAATTGGTTG
+    active: true
+  - name: G1-50C
+    seq: TCATTTTGCTGCAAGTCTCG
+    active: true
+  - name: G2-50C
+    seq: ATTTCGATTTCGGCGATACG
+    active: true
+  - name: G3-50C
+    seq: TTCTTATCGCCAACAGTCAG
+    active: true
+  - name: G3a
+    seq: ATTTGAATAGCTCGCCTGAA
+    active: true
+  - name: G4-50C
+    seq: CTATTGCTAGACTCAGATTGC
+    active: true
+  - name: G4a-50C
+    seq: TTCGTAACAGACATGGTTTTG
+    active: true
+  - name: gh+
+    seq: GACTTACACACCTGCATACC
+    active: true
+  - name: GHG
+    seq: AGGTATGCAGGTGTGTAAGTC
+    active: true
+  - name: 50C 1 outward
+    seq: GCACCAAGGGAGCTGTGATT
+    active: true
+  - name: '2954'
+    seq: CTCGTTTATCGgTACATAAAACAC
+    active: true
+  - name: '2958'
+    seq: GTGTTTTATGTAcCGATAAACGAG
+    active: true
+  - name: for making w-hdf
+    seq: GCATGGTCTGGCCATTCTCATC
+    active: true
+  - name: hdfG
+    seq: GAGAATGGCCAGACCATGCATGGGCCAGACCCACGTAGTCCA
+    active: true
+  - name: Hi+
+    seq: TTTTTTGTGACCTGTTCGGAGTGA
+    active: true
+  - name: HID
+    seq: GCGACTGTCGTTAGTTCCGC
+    active: true
+  - name: hobo0
+    seq: GGGGATCCACCCGATAAACACTCGG
+    active: true
+  - name: hobo1
+    seq: GGGGATCCAGAGAACTGCAAGGG
+    active: true
+  - name: hobo2
+    seq: GGGGATCCAGAGAACTGCAGCCCGCCAC
+    active: true
+  - name: hobo6
+    seq: GGGGATCCAGAGAACTGCAGCCCG
+    active: true
+  - name: weak 17C match
+    seq: CCTGAAGATGTGCTGCGGGTGG
+    active: true
+  - name: hobo9
+    seq: GACAAAGAGTTCCATTGTCTC
+    active: true
+  - name: g20138.1c but not g112.1a
+    seq: CGACAGTCGCTCCAAGGCAT
+    active: true
+  - name: '4496'
+    seq: GGTTGGCGCGaTCTCGCGCTCT
+    active: true
+  - name: '4409'
+    seq: CGAGAtCGCGCCAACCAAGTAGCGATAGAT
+    active: true
+  - name: IG
+    seq: CGCGCCAACCAAGTAGCGATAG
+    active: true
+  - name: insert with NdeI
+    seq: CATGATGAAATAACATAtgTAGGGATAACAGGGTAATTATGTTATTTCATCATG
+    active: true
+  - name: ordered 8 September 1997
+    seq: tgTAGGGATAACAGGGTAATTATGTTATTTCATCATG
+    active: true
+  - name: isecI18
+    seq: TAGGGATAACAGGGTAAT
+    active: true
+  - name: '2957'
+    seq: TTACGAATTCAGGACCTATTTCCGCTGCAC
+    active: true
+  - name: J+2
+    seq: AGTGCAGCGGAAATAGGACC
+    active: true
+  - name: J-D
+    seq: GTGCAGCGGAAATAGGACCTAAC
+    active: true
+  - name: J-plus
+    seq: GTGCAGCGGAAATAGTTAATAAC
+    active: true
+  - name: jockey1
+    seq: GGATTAAAAATCTGTTAGTC
+    active: true
+  - name: jockey2
+    seq: TAGGTCAAAACCAGGTTAGG
+    active: true
+  - name: Jockey3
+    seq: TAGGGAGGTCATGAGGGTGG
+    active: true
+  - name: jockeyD
+    seq: TCTACTCTTACAACCCTTTG
+    active: true
+  - name: JockeyG
+    seq: ctagcttccttgctaggctg
+    active: true
+  - name: kimer
+    seq: CCCCAGTTCGGGCAAGGTCATCCTG
+    active: true
+  - name: left end
+    seq: ACCTTATGTTATTTCATCAT
+    active: true
+  - name: mam-Da
+    seq: GCATCAGCAACACTTGGGCCTC
+    active: true
+  - name: mam-Db
+    seq: CAGCAGCAGCAGATCCAAGTTC
+    active: true
+  - name: mam-Dc
+    seq: CGTCGATCTCAAGCGTCTGC
+    active: true
+  - name: mam-GA
+    seq: GTGGGTACCGCTCCTGGATTTGTAG
+    active: true
+  - name: mam-Gc
+    seq: GGAAGTTGGCCGCCGCATTG
+    active: true
+  - name: middle
+    seq: TGGGTTTATCCAGAATTCC
+    active: true
+  - name: Nest-a3
+    seq: gaaataacataaggtggtccCAT
+    active: true
+  - name: Nest-a6
+    seq: acataaggtggtccCATGat
+    active: true
+  - name: Nest-b3
+    seq: CGGCTTTCGACGggaccaccCAT
+    active: true
+  - name: Nest-b6
+    seq: TCGACGggaccaccCATGat
+    active: true
+  - name: out
+    seq: TGCAAGCATACGTTAAGTGG
+    active: true
+  - name: Afl II
+    seq: CGTGGGTCTtaagCATGATGAAATAACATAAGGTGGTCCCGTCGAAAGC
+    active: true
+  - name: P-out3
+    seq: CGGGACCACCTTATGTTATTTCATC
+    active: true
+  - name: P19
+    seq: CATGATGAAATAACATAAG
+    active: true
+  - name: P2573G
+    seq: ACATCGACGTTTCGCGCTGC
+    active: true
+  - name: PoutD-50C
+    seq: TATGTTATTTCATCATGgccc
+    active: true
+  - name: puc19D
+    seq: GTAAAACGACGGCCAGT
+    active: true
+  - name: adds BamHI site
+    seq: GCGCGGATCCAAGCTTGCATGCCTGC
+    active: true
+  - name: right end
+    seq: TGATGAAATAACATAA
+    active: true
+  - name: ry1
+    seq: TCTCCCTTTGGGTGCCCTCAT
+    active: true
+  - name: ordered 20 April 1998
+    seq: CATGATGAAATAACATAtgTAGGGATAACAGGGTAAT
+    active: true
+  - name: singed
+    seq: TTcacgattcgagattactG
+    active: true
+  - name: t'ase
+    seq: ATMCACTTAA
+    active: true
+  - name: T33
+    seq: CATAAGGTGGTCCCGTCGAT
+    active: true
+  - name: tigA
+    seq: TGAAGGCATTAGCTCTCCAC
+    active: true
+  - name: 15 November 1996
+    seq: ACATGTGGATGTCGTTGCGA
+    active: true
+  - name: tigD
+    seq: GCAGCTCCCTAACAGCCATC
+    active: true
+  - name: U1aD
+    seq: GGGTCTTTCTGCTTCAGTTACC
+    active: true
+  - name: U1aG
+    seq: GGAATACACGAATCCCCCTT
+    active: true
+  - name: Eco RI
+    seq: AgttAACAgAAttCACACTGCCCACACGCACAC
+    active: true
+  - name: w-1D
+    seq: CTGCACTGGACATCATTG
+    active: true
+  - name: w-1D20
+    seq: AGTCAGCGCTGTTTGCCTCC
+    active: true
+  - name: w-1G
+    seq: GTTAGTTGTGCAAACTGCAC
+    active: true
+  - name: w-exn1
+    seq: CATCTGCCGAGCATCTGAAC
+    active: true
+  - name: w-int1
+    seq: GATTAGCCAGGCTGGGCTAG
+    active: true
+  - name: wallyD
+    seq: TACGCAATTTTCTTGAGCGG
+    active: true
+  - name: wallyG
+    seq: TTAATAGTCGAGGATCCTGC
+    active: true
+  - name: whd+
+    seq: CTACGTGGGTCTGGCCCATGA
+    active: true
+  - name: whd-
+    seq: ATGAGAATGGCCAGACCATGA
+    active: true
+  - name: white intron G
+    seq: GGTCGATGTATAACGTAGTG
+    active: true
+  - name: from GG 18 November 1993
+    seq: CAACACAACTTATGCCGCGT
+    active: true
+  - name: Y/Z
+    seq: tttcagctttccgcaacagtaTaa
+    active: true
+  - name: YD1
+    seq: GCGAATTCGGAGATACGAGC
+    active: true
+  - name: yD2
+    seq: ATATGTTCTTAAGCAGTCCG
+    active: true
+  - name: yD3
+    seq: ATGCATTCTATGCACGAGCC
+    active: true
+  - name: yD4
+    seq: CGATCGCATCATTAGTTGCG
+    active: true
+  - name: yG1
+    seq: ATTACCGGCAATGCTGCTCG
+    active: true
+  - name: yG2
+    seq: CTTTACATGAGGGTGCTCTC
+    active: true
+  - name: yG3
+    seq: TATCGATTTACCGACCCATC
+    active: true
+  - name: yz1
+    seq: ccctggttttggttttgtagagt
+    active: true
+  - name: yz2
+    seq: actctacaaaaccaaaaccaggg
+    active: true
+  - name: ''
+    seq: ''
+    active: false


### PR DESCRIPTION
The PCR view rendered incorrectly when toggling the Circular checkbox because of two issues:

1. run_pcr() was called before switch_view(), so canvas shapes were sent to the browser while the PCR view was not the active content. Flet's diff algorithm marked them as 'already sent', causing a partial draw (text labels appeared but canvas shapes did not).

2. The cache mechanism (clear_cache, _cached_pcr, etc.) added complexity without preventing the stale render.

Changes:
- Remove _cached_pcr/_cached_state_key from PCRView
- Remove _cached_dimers/_cached_state_key from DimerView
- Remove clear_cache() from both views
- Reorder on_pcr_click: switch_view first, then run_pcr
- Reorder on_dimers_click: same approach
- Fix on_platform_brightness_change to check active view via view_container.content instead of diagram_container
- Force new list ref in canvas shapes for Flet detection