### PR TITLE
ci: bump version to 1.0.0 and automate release

### DIFF
--- a/.github/workflows/push_stable.yml
+++ b/.github/workflows/push_stable.yml
@@ -4,8 +4,23 @@ on:
     branches: [stable]
   workflow_dispatch:
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: python
   build:
     name: Build artifacts (${{ matrix.os }})
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created }}
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -86,41 +101,30 @@ jobs:
             amplifyp-macos.dmg
             amplifyp-windows.zip
           if-no-files-found: ignore
-  release:
-    name: Create GitHub Release
-    needs: [build]
+  upload-assets:
+    name: Upload Assets to GitHub Release
+    needs: [release-please, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
-      - name: Get version and short SHA
-        id: info
-        shell: bash
-        run: |
-          VERSION=$(grep -m 1 'version =' pyproject.toml | cut -d '"' -f 2)
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
       - name: Download all workflow artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: amplifyp-*
           merge-multiple: true
-      - name: Create Pre-release
+      - name: Upload assets to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.info.outputs.version }}-${{ steps.info.outputs.sha }}" \
-            --prerelease \
-            --title "Release ${{ steps.info.outputs.version }} (${{ steps.info.outputs.sha }})" \
+          gh release upload ${{ needs.release-please.outputs.tag_name }} \
             amplifyp-linux.tar.gz \
             amplifyp-macos.dmg \
             amplifyp-windows.zip \
             amplifyp-web.tar.gz
   deploy:
     name: Deploy to GitHub Pages
-    needs: [build]
+    needs: [release-please, build]
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-06-30
+
+Initial release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "amplifyp"
-version = "v0.95.5"
+version = "1.0.0"
 description = """\
 Modern Python rewrite of Amplify4 for PCR simulation, \
 amplicon prediction, and primer dimer analysis\

--- a/src/README.md
+++ b/src/README.md
@@ -162,17 +162,9 @@ pytest --run-slow -m e2e
 
 ______________________________________________________________________
 
-## 6. Version Release Checklist
+## 6. Automated Release Process
 
-When preparing a new release of AmplifyP, you must update the version string in
-the following files:
-
-1. **`pyproject.toml`**: Update the `version` field under `[project]`
-   ```toml
-   [project]
-   version = "v0.95.5"
-   ```
-1. **`src/amplifyp/__init__.py`**: Update the `__version__` variable
-   ```python
-   __version__ = "v0.95.5"
-   ```
+The release process is automated via GitHub Actions using [release-please]
+(https://github.com/googleapis/release-please). Version bumps in
+`pyproject.toml` and `src/amplifyp/__init__.py` are handled automatically based
+on conventional commits.

--- a/src/amplifyp/__init__.py
+++ b/src/amplifyp/__init__.py
@@ -21,4 +21,4 @@ replication configurations, and calculating binding statistics such as
 primability and stability.
 """
 
-__version__ = "v0.95.5"
+__version__ = "1.0.0"


### PR DESCRIPTION
- Bump package version to 1.0.0 in pyproject.toml and __init__.py

- Add changelog and initial release information

- Integrate google-github-actions/release-please-action in workflows