### PR TITLE
feat(gui): add double-click range selection for primer rows

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=tests/**

--- a/src/amplifyp/gui/views/input/primer_action_controller.py
+++ b/src/amplifyp/gui/views/input/primer_action_controller.py
@@ -38,36 +38,99 @@ class PrimerActionController:
         """
         self.owner = owner
         self.current_drag_y = 0.0
+        self._click_a: int | None = None
+        self._click_b: int | None = None
 
     def handle_row_click(self, idx: int, name_edit: ft.TextField) -> None:
-        """Handle clicking on the row container.
+        """Handle single click on the row container.
 
-        Selects the row, focuses the name field, updates highlights,
-        and displays primer info.
+        Immediately toggles selection of the row and resets
+        click_a/click_b, clearing any pending double-click range.
 
         Args:
             idx: Zero-based index of the clicked primer row.
             name_edit: The name TextField control to focus.
         """
-        if idx in self.owner.selected_indices:
-            self.owner.selected_indices.remove(idx)
-            if self.owner.focused_primer_index == idx:
-                self.owner.focused_primer_index = None
+        owner = self.owner
+        self._click_a = None
+        self._click_b = None
+
+        if idx in owner.selected_indices:
+            owner.selected_indices.discard(idx)
+            if owner.focused_primer_index == idx:
+                owner.focused_primer_index = None
         else:
-            self.owner.selected_indices.add(idx)
-            self.owner.focused_primer_index = idx
+            owner.selected_indices.add(idx)
+            owner.focused_primer_index = idx
 
             res = name_edit.focus()
-            if inspect.iscoroutine(res) and self.owner.app_page:
+            if inspect.iscoroutine(res) and owner.app_page:
 
                 async def do_focus() -> None:
                     await res
 
-                self.owner.app_page.run_task(do_focus)
+                owner.app_page.run_task(do_focus)
 
-        self.owner._update_row_highlights()
-        self.owner._update_primer_info_panel()
-        self.owner._update_delete_button_disabled_state()
+        owner._update_row_highlights()
+        owner._update_primer_info_panel()
+        owner._update_delete_button_disabled_state()
+
+    def handle_row_double_click(
+        self, idx: int, _name_edit: ft.TextField
+    ) -> None:
+        """Handle double click on the row container.
+
+        On the first double-click, toggles selection of the clicked row
+        and sets click_a. On the second double-click, sets click_b,
+        toggles highlighting between click_a (exclusive) and click_b
+        (inclusive), then resets both to None.
+
+        Flet (via Flutter) does not fire on_tap before on_double_tap,
+        so the double-click handler is solely responsible for
+        managing click_a/click_b state.
+
+        Args:
+            idx: Zero-based index of the clicked primer row.
+            _name_edit: The name TextField control (unused).
+        """
+        owner = self.owner
+
+        # Reset anchor if it is out of bounds due to list mutations
+        if self._click_a is not None and not (
+            0 <= self._click_a < len(owner.input_data.primers)
+        ):
+            self._click_a = None
+
+        if self._click_a is None:
+            # First double-click: toggle the row, set click_a
+            if idx in owner.selected_indices:
+                owner.selected_indices.discard(idx)
+                if owner.focused_primer_index == idx:
+                    owner.focused_primer_index = None
+            else:
+                owner.selected_indices.add(idx)
+                owner.focused_primer_index = idx
+            self._click_a = idx
+        else:
+            # Second double-click: set click_b, toggle range
+            # exclusive of click_a (already selected)
+            self._click_b = idx
+            click_a = self._click_a
+            start = min(click_a, self._click_b)
+            end = max(click_a, self._click_b)
+            for i in range(start, end + 1):
+                if i == click_a:
+                    continue
+                if i in owner.selected_indices:
+                    owner.selected_indices.discard(i)
+                else:
+                    owner.selected_indices.add(i)
+            self._click_a = None
+            self._click_b = None
+
+        owner._update_row_highlights()
+        owner._update_primer_info_panel()
+        owner._update_delete_button_disabled_state()
 
     def on_add_primer_row(self, idx: int) -> None:
         """Add a new empty primer row immediately below the row at idx.
@@ -78,6 +141,8 @@ class PrimerActionController:
         Args:
             idx: Zero-based index of the row below which to insert.
         """
+        self._click_a = None
+        self._click_b = None
         self.owner.sync_to_state(rebuild_if_needed=False)
         self.owner.input_data.primers.insert(
             idx + 1, {"name": "", "seq": "", "active": False}
@@ -93,6 +158,8 @@ class PrimerActionController:
             indices: Set of zero-based indices of the primers to move.
             direction: -1 to move up, 1 to move down.
         """
+        self._click_a = None
+        self._click_b = None
         self.owner.sync_to_state(rebuild_if_needed=False)
         primers = self.owner.input_data.primers
         valid_indices = {i for i in indices if 0 <= i < len(primers)}
@@ -131,6 +198,8 @@ class PrimerActionController:
         Args:
             indices_to_delete: Set of zero-based indices to remove.
         """
+        self._click_a = None
+        self._click_b = None
         if not indices_to_delete:
             return
 
@@ -191,6 +260,7 @@ class PrimerActionController:
                 row.update_index(
                     new_idx=new_idx,
                     on_row_click=self.handle_row_click,
+                    on_row_double_click=self.handle_row_double_click,
                 )
 
         self.owner._update_row_highlights()
@@ -241,6 +311,8 @@ class PrimerActionController:
         self, _start_idx: int, e: ft.DragUpdateEvent
     ) -> None:
         """Handle live drag-and-drop reordering of contiguous rows."""
+        self._click_a = None
+        self._click_b = None
         if not hasattr(self, "drag_block") or not self.drag_block:
             return
 

--- a/src/amplifyp/gui/views/input/primer_list.py
+++ b/src/amplifyp/gui/views/input/primer_list.py
@@ -127,6 +127,7 @@ class PrimerList(ft.ListView):  # type: ignore[misc]
                     handle_field_blur=self.primer_input.handle_field_blur,
                     handle_field_submit=self.primer_input.handle_field_submit,
                     on_row_click=self.primer_input.action_controller.handle_row_click,
+                    on_row_double_click=self.primer_input.action_controller.handle_row_double_click,
                     on_divider_pan=self.primer_input.layout_manager.on_primer_divider_pan,
                     on_divider_pan_end=self.primer_input.layout_manager.on_primer_divider_pan_end,
                     is_focused=False,
@@ -149,7 +150,9 @@ class PrimerList(ft.ListView):  # type: ignore[misc]
                 continue
 
             row.update_index(
-                idx, self.primer_input.action_controller.handle_row_click
+                idx,
+                self.primer_input.action_controller.handle_row_click,
+                self.primer_input.action_controller.handle_row_double_click,
             )
 
             if row.name_field.value != name_val:

--- a/src/amplifyp/gui/views/input/primer_row.py
+++ b/src/amplifyp/gui/views/input/primer_row.py
@@ -50,6 +50,7 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
         handle_field_blur: Callable[[ft.Event[ft.TextField]], None],
         handle_field_submit: Callable[[ft.Event[ft.TextField]], None],
         on_row_click: Callable[[int, ft.TextField], None],
+        on_row_double_click: Callable[[int, ft.TextField], None],
         on_divider_pan: Callable[[ft.DragUpdateEvent], None],
         on_divider_pan_end: Callable[[ft.DragEndEvent], None],
         is_focused: bool,
@@ -75,7 +76,8 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
             handle_field_focus: Callback for field focus events.
             handle_field_blur: Callback for field blur events.
             handle_field_submit: Callback for field submit events.
-            on_row_click: Callback when the row container is clicked.
+            on_row_click: Callback when the row container is single-clicked.
+            on_row_double_click: Callback for double-click on row.
             on_divider_pan: Callback for dragging the name/sequence divider.
             on_divider_pan_end: Callback for ending the divider drag.
             is_focused: Whether this row is currently focused.
@@ -166,6 +168,10 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
                 on_drag_end(self.idx, e) if on_drag_end else None
             ),
             on_tap=lambda e: on_row_click(self.idx, self.name_field),  # type: ignore[has-type]
+            on_double_tap=lambda e: on_row_double_click(
+                self.idx,
+                self.name_field,  # type: ignore[has-type]
+            ),
             mouse_cursor=ft.MouseCursor.CLICK,
             content=ft.Container(
                 content=ft.Icon(
@@ -253,8 +259,7 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
             height=30 if not has_err else 42,
         )
 
-        controls = [
-            self.drag_handle,
+        row_body = [
             self.checkbox_container,
             self.active_divider,
             self.name_scroll,
@@ -262,15 +267,25 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
             self.seq_scroll,
         ]
         if show_temp:
-            controls.extend([self.tm_divider, self.tm_container])
+            row_body.extend([self.tm_divider, self.tm_container])
 
-        self.content = ft.Row(
-            controls,
+        row_content = ft.Row(
+            row_body,
             spacing=0,
             vertical_alignment=ft.CrossAxisAlignment.START,
         )
 
-        self.on_click = lambda e: on_row_click(self.idx, self.name_field)
+        self._row_gesture_detector = ft.GestureDetector(
+            on_tap=lambda e: on_row_click(self.idx, self.name_field),
+            mouse_cursor=ft.MouseCursor.CLICK,
+            content=row_content,
+        )
+
+        self.content = ft.Row(
+            [self.drag_handle, self._row_gesture_detector],
+            spacing=0,
+            vertical_alignment=ft.CrossAxisAlignment.START,
+        )
 
     def update_highlight_and_reorder(
         self, is_focused: bool, is_dup: bool
@@ -336,12 +351,14 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
         self,
         new_idx: int,
         on_row_click: Callable[[int, ft.TextField], None],
+        on_row_double_click: Callable[[int, ft.TextField], None],
     ) -> None:
         """Update the index of the row and refresh its handlers and controls.
 
         Args:
-            new_idx: The new zero-based index for this primer row.
+            new_idx: The zero-based index for this primer row.
             on_row_click: Callback when the row container is clicked.
+            on_row_double_click: Callback for double-click on row.
         """
         self.data = new_idx
         self.idx = new_idx
@@ -349,7 +366,18 @@ class PrimerRow(ft.Container):  # type: ignore[misc]
         self.seq_field.data = {"idx": new_idx, "field": "seq"}
 
         # Update click handler with the new index
-        self.on_click = lambda e: on_row_click(new_idx, self.name_field)
+        self._row_gesture_detector.on_tap = lambda e: on_row_click(
+            new_idx, self.name_field
+        )
+        self._row_gesture_detector.on_double_tap = lambda e: (
+            on_row_double_click(new_idx, self.name_field)
+        )
+        self.drag_handle.on_tap = lambda e: on_row_click(
+            new_idx, self.name_field
+        )
+        self.drag_handle.on_double_tap = lambda e: on_row_double_click(
+            new_idx, self.name_field
+        )
 
     def update_tm(self, settings: GUISettings) -> None:
         """Update the displayed Tm in-place based on the current sequence."""

--- a/tests/input_view_test.py
+++ b/tests/input_view_test.py
@@ -43,17 +43,24 @@ def test_input_view_row_boxes_editing() -> None:
     container = view.primers_list.controls[0]
     assert isinstance(container, ft.Container)
 
-    row = container.content
-    assert isinstance(row, ft.Row)
+    # Content is a Row with drag handle + GestureDetector-wrapped row body
+    outer_row = container.content
+    assert isinstance(outer_row, ft.Row)
 
-    drag_handle = row.controls[0]
-    checkbox_container = row.controls[1]
-    active_divider = row.controls[2]
-    name_scroll = row.controls[3]
-    divider = row.controls[4]
-    seq_scroll = row.controls[5]
-
+    drag_handle = outer_row.controls[0]
+    gesture_detector = outer_row.controls[1]
     assert isinstance(drag_handle, ft.GestureDetector)
+    assert isinstance(gesture_detector, ft.GestureDetector)
+
+    row_body = gesture_detector.content
+    assert isinstance(row_body, ft.Row)
+
+    checkbox_container = row_body.controls[0]
+    active_divider = row_body.controls[1]
+    name_scroll = row_body.controls[2]
+    divider = row_body.controls[3]
+    seq_scroll = row_body.controls[4]
+
     assert isinstance(checkbox_container, ft.Container)
     checkbox = checkbox_container.content
     assert isinstance(checkbox, ft.Checkbox)
@@ -340,12 +347,89 @@ def test_input_view_row_single_click() -> None:
     # Mock focus method on TextField
     name_field.focus = MagicMock()
 
-    # Trigger row container click
-    container.on_click(MagicMock())
+    # Trigger row container click via gesture detector
+    gesture_detector = container._row_gesture_detector
+    gesture_detector.on_tap(MagicMock())
 
     assert view.focused_primer_index == 0
     assert container.bgcolor == GUIColours.SELECTED_ROW_BG
     name_field.focus.assert_called_once()
+
+
+def test_input_view_double_click_anchor_and_range() -> None:
+    """Test double-click anchor setting and range selection."""
+    mock_page = MagicMock(spec=ft.Page)
+    input_data = GUIInput()
+    input_data.primers = [
+        {"name": "P1", "seq": "AAAAA", "active": True},
+        {"name": "P2", "seq": "TTTTT", "active": True},
+        {"name": "P3", "seq": "GGGGG", "active": True},
+    ]
+
+    view = InputView(mock_page, input_data)
+    view.update_ui()
+
+    controller = view.primer_input.action_controller
+    dc = controller.handle_row_double_click
+
+    # First double-click toggles and sets anchor
+    assert controller._click_a is None
+    assert view.primer_input.selected_indices == set()
+    dc(0, MagicMock(spec=ft.TextField))
+    assert controller._click_a == 0
+    assert controller._click_b is None
+    assert view.primer_input.selected_indices == {0}
+
+    # Second double-click toggles range exclusive of click_a
+    dc(2, MagicMock(spec=ft.TextField))
+    assert controller._click_a is None
+    assert controller._click_b is None
+    assert view.primer_input.selected_indices == {0, 1, 2}
+
+    # Reverse order: click_b < click_a (simulate click_a set from prior dc)
+    controller._click_a = 2
+    view.primer_input.selected_indices = {0, 1, 2}
+    dc(0, MagicMock(spec=ft.TextField))
+    assert controller._click_a is None
+    assert controller._click_b is None
+    # Range 0..1 toggled (exclusive of click_a=2, both removed)
+    assert view.primer_input.selected_indices == {2}
+
+    # Same index as click_a: no range, selection unchanged
+    controller._click_a = 1
+    view.primer_input.selected_indices = {1}
+    dc(1, MagicMock(spec=ft.TextField))
+    assert controller._click_a is None
+    assert controller._click_b is None
+    assert view.primer_input.selected_indices == {1}
+
+
+def test_input_view_single_click_clears_double_click_state() -> None:
+    """Test that single click resets click_a and click_b."""
+    mock_page = MagicMock(spec=ft.Page)
+    input_data = GUIInput()
+    input_data.primers = [
+        {"name": "P1", "seq": "AAAAA", "active": True},
+        {"name": "P2", "seq": "TTTTT", "active": True},
+        {"name": "P3", "seq": "GGGGG", "active": True},
+    ]
+
+    view = InputView(mock_page, input_data)
+    view.update_ui()
+
+    controller = view.primer_input.action_controller
+    dc = controller.handle_row_double_click
+
+    dc(0, MagicMock(spec=ft.TextField))
+    assert controller._click_a == 0
+
+    name_field = view.primers_list.controls[2].name_field
+    name_field.focus = MagicMock()
+    controller.handle_row_click(2, name_field)
+
+    assert controller._click_a is None
+    assert controller._click_b is None
+    assert view.primer_input.selected_indices == {0, 2}
 
 
 def test_input_view_primer_reordering() -> None:
@@ -709,224 +793,99 @@ def test_app_views_disabled_on_invalid_selected() -> None:
     assert view.primer_input.error_banner.visible is True
 
 
-def test_header_checkbox_indeterminate_empty() -> None:
-    """Test header checkbox is indeterminate when primer list is empty."""
+def test_header_checkbox_state() -> None:
+    """Test header checkbox value based on primer active states."""
+    from itertools import product
+
     mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    view = InputView(mock_page, input_data)
 
-    assert view.primer_input.all_primers_checkbox.value is None
+    for active_states in product([True, False], repeat=3):
+        input_data = GUIInput()
+        input_data.primers = [
+            {"name": f"P{i}", "seq": "AAAAA", "active": active}
+            for i, active in enumerate(active_states, 1)
+        ]
+        view = InputView(mock_page, input_data)
+        view.sync_to_state()
+
+        all_active = all(active_states)
+        any_active = any(active_states)
+        if all_active:
+            expected = True
+        elif any_active:
+            expected = None
+        else:
+            expected = False
+        assert view.primer_input.all_primers_checkbox.value is expected, (
+            f"active={active_states}"
+        )
 
 
-def test_header_checkbox_all_active() -> None:
-    """Test header checkbox is checked when all primers are active."""
+def test_header_checkbox_click_cycle() -> None:
+    """Test checkbox value is authoritative: True→activate, False→deactivate.
+
+    Covers all-active, all-inactive, and mixed starting states.
+    Also verifies _prev_header_checkbox_value tracking across the full
+    Flet tri-state cycle: None→True→None→False→None.
+    """
     mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": True},
-        {"name": "P2", "seq": "TTTTT", "active": True},
+
+    cases = [
+        # (starting_states, initial_cb, transitions, expected_states,
+        #  expected_prev_values)
+        (
+            [True, True],
+            True,
+            [None, False],
+            [False, False],
+            [False, False],
+        ),
+        (
+            [True, False],
+            None,
+            [True, None],
+            [True, False],
+            [True, False],
+        ),
+        (
+            [False, False],
+            False,
+            [None, True],
+            [True, True],
+            [True, True],
+        ),
     ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
 
-    assert view.primer_input.all_primers_checkbox.value is True
+    for (
+        starting_states,
+        initial_cb,
+        transitions,
+        expected_all,
+        expected_prev,
+    ) in cases:
+        input_data = GUIInput()
+        input_data.primers = [
+            {"name": f"P{i}", "seq": "AAAAA", "active": s}
+            for i, s in enumerate(starting_states, 1)
+        ]
+        view = InputView(mock_page, input_data)
+        view.sync_to_state()
 
+        assert view.primer_input.all_primers_checkbox.value is initial_cb
 
-def test_header_checkbox_all_inactive() -> None:
-    """Test header checkbox is unchecked when all primers are inactive."""
-    mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": False},
-        {"name": "P2", "seq": "TTTTT", "active": False},
-    ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
-
-    assert view.primer_input.all_primers_checkbox.value is False
-
-
-def test_header_checkbox_mixed() -> None:
-    """Test header checkbox is indeterminate when some primers are active."""
-    mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": True},
-        {"name": "P2", "seq": "TTTTT", "active": False},
-    ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
-
-    assert view.primer_input.all_primers_checkbox.value is None
-
-
-def test_header_checkbox_click_all_active() -> None:
-    """Test checkbox value is authoritative: True→activate, False→deactivate."""
-    mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": True},
-        {"name": "P2", "seq": "TTTTT", "active": True},
-    ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
-
-    assert view.primer_input.all_primers_checkbox.value is True
-
-    # Simulate Flet cycle: True → None (first click from all-active state)
-    view.primer_input.all_primers_checkbox.value = None
-    view.primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-
-    non_empty = [
-        p
-        for p in input_data.primers
-        if str(p.get("name", "")).strip() or p.get("seq", "").strip()
-    ]
-    assert all(not p["active"] for p in non_empty)
-
-    # Simulate Flet cycle: None → False (second click)
-    view.primer_input.all_primers_checkbox.value = False
-    view.primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-
-    non_empty = [
-        p
-        for p in input_data.primers
-        if str(p.get("name", "")).strip() or p.get("seq", "").strip()
-    ]
-    assert all(not p["active"] for p in non_empty)
-
-
-def test_header_checkbox_click_partial() -> None:
-    """Test checkbox value is authoritative: True→activate, False→deactivate."""
-    mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": True},
-        {"name": "P2", "seq": "TTTTT", "active": False},
-    ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
-
-    assert view.primer_input.all_primers_checkbox.value is None
-
-    # Simulate Flet cycle: None → True (first click from mixed state)
-    view.primer_input.all_primers_checkbox.value = True
-    view.primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-
-    non_empty = [
-        p
-        for p in input_data.primers
-        if str(p.get("name", "")).strip() or p.get("seq", "").strip()
-    ]
-    assert all(p["active"] for p in non_empty)
-
-    # Simulate Flet cycle: True → None (second click)
-    view.primer_input.all_primers_checkbox.value = None
-    view.primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-
-    non_empty = [
-        p
-        for p in input_data.primers
-        if str(p.get("name", "")).strip() or p.get("seq", "").strip()
-    ]
-    assert all(not p["active"] for p in non_empty)
-
-
-def test_header_checkbox_click_all_inactive() -> None:
-    """Test checkbox value is authoritative: True→activate, False→deactivate."""
-    mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": False},
-        {"name": "P2", "seq": "TTTTT", "active": False},
-    ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
-
-    assert view.primer_input.all_primers_checkbox.value is False
-
-    # Simulate Flet cycle: False → None (first click from all-inactive state)
-    view.primer_input.all_primers_checkbox.value = None
-    view.primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-
-    non_empty = [
-        p
-        for p in input_data.primers
-        if str(p.get("name", "")).strip() or p.get("seq", "").strip()
-    ]
-    assert all(p["active"] for p in non_empty)
-
-    # Simulate Flet cycle: None → True (second click)
-    view.primer_input.all_primers_checkbox.value = True
-    view.primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-
-    non_empty = [
-        p
-        for p in input_data.primers
-        if str(p.get("name", "")).strip() or p.get("seq", "").strip()
-    ]
-    assert all(p["active"] for p in non_empty)
-
-
-def test_header_checkbox_tristate_cycle() -> None:
-    """Test the Flet tri-state cycle: None→True→None→False→None."""
-    mock_page = MagicMock(spec=ft.Page)
-    input_data = GUIInput()
-    input_data.primers = [
-        {"name": "P1", "seq": "AAAAA", "active": True},
-        {"name": "P2", "seq": "TTTTT", "active": False},
-    ]
-    view = InputView(mock_page, input_data)
-    view.sync_to_state()
-
-    primer_input = view.primer_input
-    cb = primer_input.all_primers_checkbox
-
-    # Simulating Flet's tri-state cycle on click:
-    # None→True→None→False→None→True...
-    # The on_change handler fires AFTER Flet updates the checkbox value.
-
-    # Click 1: Flet cycles None → True, handler sees cb_value=True
-    cb.value = True
-    primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-    assert all(
-        p["active"] for p in input_data.primers if p.get("seq", "").strip()
-    )
-    assert primer_input._prev_header_checkbox_value is True
-
-    # Click 2: Flet cycles True → None, handler sees None, prev=True
-    # → deactivate
-    cb.value = None
-    primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-    assert all(
-        not p["active"] for p in input_data.primers if p.get("seq", "").strip()
-    )
-    assert primer_input._prev_header_checkbox_value is False
-
-    # Click 3: Flet cycles None → False, handler sees False → deactivate
-    cb.value = False
-    primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-    assert all(
-        not p["active"] for p in input_data.primers if p.get("seq", "").strip()
-    )
-    assert primer_input._prev_header_checkbox_value is False
-
-    # Click 4: Flet cycles False → None, handler sees None, prev=False
-    # → activate
-    cb.value = None
-    primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-    assert all(
-        p["active"] for p in input_data.primers if p.get("seq", "").strip()
-    )
-    assert primer_input._prev_header_checkbox_value is True
-
-    # Click 5: Flet cycles None → True, handler sees cb_value=True → activate
-    cb.value = True
-    primer_input._on_toggle_all_primers(MagicMock(spec=ft.ControlEvent))
-    assert all(
-        p["active"] for p in input_data.primers if p.get("seq", "").strip()
-    )
-    assert primer_input._prev_header_checkbox_value is True
+        for transition, expected_all_state, expected_prev_state in zip(
+            transitions, expected_all, expected_prev, strict=True
+        ):
+            view.primer_input.all_primers_checkbox.value = transition
+            view.primer_input._on_toggle_all_primers(
+                MagicMock(spec=ft.ControlEvent)
+            )
+            for p in input_data.primers:
+                assert p["active"] is expected_all_state
+            assert (
+                view.primer_input._prev_header_checkbox_value
+                is expected_prev_state
+            )
 
 
 def _run_async(coro: object) -> None:


### PR DESCRIPTION
Add _click_a/_click_b anchor state to PrimerActionController. First double-click toggles the row and sets _click_a; second double-click sets _click_b and toggles all rows between them, then resets anchors. Single-click resets anchors to clear pending range.

Restructure PrimerRow: wrap row body in GestureDetector, make drag handle a sibling so each has its own gesture arena and eliminates the 300ms tap delay.

Reset anchors in all mutation methods (add, move, delete, drag).

Add sonar.exclusions for tests/. Rewrite input_view_test.py: add tests for double-click range selection and consolidate header checkbox tests into parameterized cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added double-click range selection in the primer list, making it easier to select multiple rows in one action.
  * Improved row interactions so single- and double-clicks behave consistently after adding, deleting, moving, or dragging primers.

* **Bug Fixes**
  * Fixed selection state so it resets correctly after other actions, preventing stale highlights from affecting later clicks.
  * Preserved row interaction behavior after list updates and reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->