### PR TITLE
feat(gui): add fixed width option for template sequence

### DIFF
--- a/src/amplifyp/gui/settings.py
+++ b/src/amplifyp/gui/settings.py
@@ -107,6 +107,8 @@ class GUISettings:
             "version_checking_frequency": "Once per Month",
             "last_version_check_timestamp": 0.0,
             "auto_reload_on_startup": True,
+            "template_fixed_width": False,
+            "template_bases_per_line": "50",
         }
 
         # Initialise base-pair weights

--- a/src/amplifyp/gui/views/input/template_input.py
+++ b/src/amplifyp/gui/views/input/template_input.py
@@ -75,6 +75,7 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
         self.handle_field_blur = handle_field_blur
         self._is_focused = False
         self._cleaned_len = 0
+        self._last_left_width: float | None = None
 
         self.template_sequence = ft.TextField(
             dense=True,
@@ -97,9 +98,47 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
             value="Insertion Point After Base: 0",
             size=12,
         )
+
+        is_fixed = self.settings.get("template_fixed_width", False)
+        self.fixed_width_tickbox = ft.Checkbox(
+            label="Fixed width:" if is_fixed else "Fixed width",
+            value=is_fixed,
+            on_change=self._handle_fixed_width_toggle,
+        )
+        self.bases_per_line_input = ft.TextField(
+            value=str(self.settings.get("template_bases_per_line", "50")),
+            width=60,
+            dense=True,
+            content_padding=ft.Padding(5, 0, 5, 0),
+            border_radius=3,
+            border_color=GUIColours.OUTLINE,
+            on_change=self._handle_bases_per_line_change,
+        )
+        self.bases_per_line_container = ft.Container(
+            content=self.bases_per_line_input,
+            height=24,
+            alignment=ft.Alignment(0, -0.2),
+            clip_behavior=ft.ClipBehavior.HARD_EDGE,
+            visible=self.settings.get("template_fixed_width", False),
+        )
+
         self.status_bar = ft.Container(
-            content=self.status_text,
-            padding=ft.Padding(10, 5, 10, 5),
+            content=ft.Row(
+                [
+                    self.status_text,
+                    ft.Container(expand=True),
+                    self.fixed_width_tickbox,
+                    self.bases_per_line_container,
+                ],
+                alignment=ft.MainAxisAlignment.START,
+                vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                height=28,
+                spacing=5,
+            ),
+            padding=ft.Padding(10, 0, 5, 0)
+            if is_fixed
+            else ft.Padding(10, 0, 10, 0),
+            height=28,
         )
 
         self.sequence_layout = ft.Row(
@@ -386,6 +425,39 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
             color=GUIColours.TEXT_ON_SURFACE,
             size=12,
         )
+        is_ticked = bool(self.fixed_width_tickbox.value)
+        self.fixed_width_tickbox.label = (
+            "Fixed width:" if is_ticked else "Fixed width"
+        )
+        self.status_bar.padding = (
+            ft.Padding(10, 0, 5, 0) if is_ticked else ft.Padding(10, 0, 10, 0)
+        )
+        self.fixed_width_tickbox.label_style = ft.TextStyle(
+            font_family=font_family,
+            color=GUIColours.TEXT_ON_SURFACE,
+            size=12,
+        )
+        self.bases_per_line_input.text_style = ft.TextStyle(
+            font_family=font_family,
+            color=GUIColours.TEXT_ON_SURFACE,
+            size=12,
+        )
+
+        val_str = (self.bases_per_line_input.value or "").strip()
+        is_valid = False
+        if val_str:
+            try:
+                val_int = int(val_str)
+                if val_int > 0:
+                    is_valid = True
+            except ValueError:
+                pass
+
+        if is_valid or not self.fixed_width_tickbox.value:
+            self.bases_per_line_input.border_color = GUIColours.OUTLINE
+        else:
+            self.bases_per_line_input.border_color = GUIColours.ERROR_RED
+
         self.status_bar.bgcolor = GUIColours.GUTTER_BG
         self.status_bar.border = ft.Border(
             top=ft.BorderSide(1, GUIColours.OUTLINE)
@@ -397,7 +469,9 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
     def adjust_wrap_length(
         self, left_width: float, update: bool = True
     ) -> None:
-        """Adjust the template wrap length based on the available width."""
+        """Adjust the wrap length based on available or fixed width."""
+        self._last_left_width = left_width
+
         font_size = max(1, self.settings.get("font_size_default", 14))
         # Monospace font character width is approximately 0.66 of font size.
         char_width = font_size * 0.66
@@ -407,11 +481,35 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
         max_digits = len(str(max(1, template_len)))
         gutter_width = 20 + max_digits * char_width
 
-        # Available width inside container for TextField text.
-        # Subtracts 20px (padding) + 12px (scrollbar) + 4px (safety margin).
-        available_width = left_width - gutter_width - 36
-        wrap_length = int(available_width / char_width)
-        wrap_length = max(20, wrap_length)
+        is_fixed = bool(self.fixed_width_tickbox.value)
+        wrap_length = None
+        if is_fixed:
+            try:
+                val_str = (self.bases_per_line_input.value or "").strip()
+                if val_str:
+                    val_int = int(val_str)
+                    if val_int > 0:
+                        wrap_length = val_int
+            except ValueError:
+                pass
+
+        if wrap_length is None:
+            # Available width inside container for TextField text.
+            # Subtracts 20px (padding) + 12px (scrollbar) + 4px (safety margin).
+            available_width = left_width - gutter_width - 36
+            wrap_length = int(available_width / char_width)
+            wrap_length = max(20, wrap_length)
+
+            # Dynamic wrapping: no horizontal scroll, let it expand
+            self.sequence_layout.scroll = None
+            self.template_sequence.width = None
+            self.template_sequence.expand = True
+        else:
+            # Fixed wrapping: enable horizontal scroll and set fixed width
+            self.sequence_layout.scroll = ft.ScrollMode.ALWAYS
+            text_field_width = wrap_length * char_width + 20
+            self.template_sequence.width = text_field_width
+            self.template_sequence.expand = False
 
         # Update TextField content with new wrapping
         self.template_sequence.value = format_sequence(
@@ -522,3 +620,69 @@ class TemplateInput(ft.Container):  # type: ignore[misc]
                     self.status_bar.update()
                 except (RuntimeError, AssertionError):
                     pass
+
+    def _handle_fixed_width_toggle(self, e: ft.ControlEvent) -> None:
+        """Handle fixed width checkbox toggle."""
+        is_ticked = bool(self.fixed_width_tickbox.value)
+        self.fixed_width_tickbox.label = (
+            "Fixed width:" if is_ticked else "Fixed width"
+        )
+        self.bases_per_line_container.visible = is_ticked
+        self.status_bar.padding = (
+            ft.Padding(10, 0, 5, 0) if is_ticked else ft.Padding(10, 0, 10, 0)
+        )
+        self.settings["template_fixed_width"] = is_ticked
+        self.settings.save_to_local(self.app_page)
+
+        # Reset or update border color when toggled
+        if is_ticked:
+            val_str = (self.bases_per_line_input.value or "").strip()
+            try:
+                val_int = int(val_str)
+                if val_int > 0:
+                    self.bases_per_line_input.border_color = GUIColours.OUTLINE
+                else:
+                    self.bases_per_line_input.border_color = (
+                        GUIColours.ERROR_RED
+                    )
+            except ValueError:
+                self.bases_per_line_input.border_color = GUIColours.ERROR_RED
+
+        if self._last_left_width is not None:
+            self.adjust_wrap_length(self._last_left_width)
+        else:
+            self.update_ui()
+
+        try:
+            self.status_bar.update()
+        except (RuntimeError, AssertionError):
+            pass
+
+    def _handle_bases_per_line_change(self, e: ft.ControlEvent) -> None:
+        """Handle bases per line text input changes."""
+        val_str = (self.bases_per_line_input.value or "").strip()
+        is_valid = False
+        if val_str:
+            try:
+                val_int = int(val_str)
+                if val_int > 0:
+                    is_valid = True
+                    self.settings["template_bases_per_line"] = val_str
+                    self.settings.save_to_local(self.app_page)
+                    self.bases_per_line_input.border_color = GUIColours.OUTLINE
+                else:
+                    self.bases_per_line_input.border_color = (
+                        GUIColours.ERROR_RED
+                    )
+            except ValueError:
+                self.bases_per_line_input.border_color = GUIColours.ERROR_RED
+        else:
+            self.bases_per_line_input.border_color = GUIColours.ERROR_RED
+
+        if is_valid and self._last_left_width is not None:
+            self.adjust_wrap_length(self._last_left_width)
+        else:
+            try:
+                self.bases_per_line_input.update()
+            except (RuntimeError, AssertionError):
+                pass

--- a/tests/input_view_test.py
+++ b/tests/input_view_test.py
@@ -1239,3 +1239,60 @@ def test_input_view_template_case_conversion() -> None:
     view.template_input._lower_case_click(MagicMock(spec=ft.Event))
     assert view.template_sequence.value == "atgatgcatg"
     assert input_data.template == "atgatgcatg"
+
+
+def test_template_input_fixed_width() -> None:
+    """Test fixed width sequence wrapping and validation in status bar."""
+    from amplifyp.gui.colours import GUIColours
+
+    mock_page = MagicMock(spec=ft.Page)
+    input_data = GUIInput()
+    input_data.template = "ATGCT" * 10  # 50 bases
+
+    view = InputView(mock_page, input_data)
+    view.update_ui()
+
+    template_input = view.template_input
+
+    # Verify default state
+    assert template_input.fixed_width_tickbox.value is False
+    assert template_input.bases_per_line_container.visible is False
+    assert template_input.bases_per_line_input.value == "50"
+
+    # Simulate ticking fixed width
+    template_input.fixed_width_tickbox.value = True
+    template_input._handle_fixed_width_toggle(MagicMock(spec=ft.ControlEvent))
+
+    assert template_input.bases_per_line_container.visible is True
+
+    # Trigger adjust_wrap_length to see if it wraps to 50
+    template_input.adjust_wrap_length(1000)
+    assert template_input.template_sequence.value == "ATGCT" * 10
+
+    # Modify bases per line to 10
+    template_input.bases_per_line_input.value = "10"
+    template_input._handle_bases_per_line_change(
+        MagicMock(spec=ft.ControlEvent)
+    )
+
+    # Verify wrapping with new length
+    template_input.adjust_wrap_length(1000)
+    expected_10 = "\n".join(["ATGCTATGCT"] * 5)
+    assert template_input.template_sequence.value == expected_10
+    assert (
+        template_input.bases_per_line_input.border_color == GUIColours.OUTLINE
+    )
+
+    # Verify invalid inputs (fallback to dynamic, and border_color = ERROR_RED)
+    template_input.bases_per_line_input.value = "-10"
+    template_input._handle_bases_per_line_change(
+        MagicMock(spec=ft.ControlEvent)
+    )
+    assert (
+        template_input.bases_per_line_input.border_color == GUIColours.ERROR_RED
+    )
+
+    # Untick fixed width
+    template_input.fixed_width_tickbox.value = False
+    template_input._handle_fixed_width_toggle(MagicMock(spec=ft.ControlEvent))
+    assert template_input.bases_per_line_container.visible is False


### PR DESCRIPTION
Add a checkbox and text input field to the status bar of the template sequence input panel, allowing the user to configure a fixed character wrap width for the sequence input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fixed-width wrapping option for template input, including a configurable “bases per line” setting.
  * Template wrapping now adapts between dynamic width and a fixed line length, with the controls shown only when needed.

* **Bug Fixes**
  * Improved validation for the bases-per-line field, with clear error feedback for invalid values.
  * Preserved template wrapping behavior when switching fixed-width mode on or off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->